### PR TITLE
fix: store readers after discovery, otherwise lookup for connection will always fail

### DIFF
--- a/one_for_all_generator/lib/src/codecs/types/date_time_codec.dart
+++ b/one_for_all_generator/lib/src/codecs/types/date_time_codec.dart
@@ -49,5 +49,5 @@ class DateTimeSwiftApiCodec extends ApiCodec<DateTime> {
 
   @override
   String encodeSerialization(ApiCodecs codecs, DartType type, String varAccess) =>
-      '$varAccess.timeIntervalSince1970 * 1000';
+      'Int($varAccess.timeIntervalSince1970 * 1000)';
 }

--- a/stripe_terminal/example/lib/main.dart
+++ b/stripe_terminal/example/lib/main.dart
@@ -221,8 +221,9 @@ class _MyAppState extends State<MyApp> {
       setState(() => _paymentIntent = paymentIntentWithPaymentMethod);
       _showSnackBar('Payment method collected!');
     } on TerminalException catch (exception) {
-      switch (exception.code) {
-        case TerminalExceptionCode.canceled:
+      switch (exception.rawCode) {
+        case "2020" ||
+              "cancelled": // TODO map error codes from swift/android and unify them for dart
           setState(() => _collectingPaymentMethod = null);
           _showSnackBar('Collecting Payment method is cancelled!');
         default:

--- a/stripe_terminal/ios/Classes/Api/StripeTerminalApi.swift
+++ b/stripe_terminal/ios/Classes/Api/StripeTerminalApi.swift
@@ -822,7 +822,7 @@ struct PaymentIntentApi {
     func serialize() -> [Any?] {
         return [
             id,
-            created.timeIntervalSince1970 * 1000,
+            Int(created.timeIntervalSince1970 * 1000),
             status.rawValue,
             amount,
             captureMethod,
@@ -837,7 +837,7 @@ struct PaymentIntentApi {
             application,
             applicationFeeAmount,
             cancellationReason,
-            canceledAt != nil ? canceledAt!.timeIntervalSince1970 * 1000 : nil,
+            canceledAt != nil ? Int(canceledAt!.timeIntervalSince1970 * 1000) : nil,
             clientSecret,
             confirmationMethod,
             customer,
@@ -987,7 +987,7 @@ struct ReaderSoftwareUpdateApi {
             components.map { $0.rawValue },
             keyProfileName,
             onlyInstallRequiredUpdates,
-            requiredAt.timeIntervalSince1970 * 1000,
+            Int(requiredAt.timeIntervalSince1970 * 1000),
             settingsVersion,
             timeEstimate.rawValue,
             version,
@@ -1036,7 +1036,7 @@ struct RefundApi {
             id,
             amount,
             chargeId,
-            created.timeIntervalSince1970 * 1000,
+            Int(created.timeIntervalSince1970 * 1000),
             currency,
             metadata != nil ? Dictionary(uniqueKeysWithValues: metadata.map { k, v in (k, v) }) : nil,
             reason,
@@ -1068,7 +1068,7 @@ struct SetupAttemptApi {
         return [
             id,
             applicationId,
-            created.timeIntervalSince1970 * 1000,
+            Int(created.timeIntervalSince1970 * 1000),
             customerId,
             onBehalfOfId,
             paymentMethodId,
@@ -1124,7 +1124,7 @@ struct SetupIntentApi {
     func serialize() -> [Any?] {
         return [
             id,
-            created.timeIntervalSince1970 * 1000,
+            Int(created.timeIntervalSince1970 * 1000),
             customerId,
             metadata != nil ? Dictionary(uniqueKeysWithValues: metadata.map { k, v in (k, v) }) : nil,
             usage.rawValue,

--- a/stripe_terminal/ios/Classes/Api/ToApiExtensions.swift
+++ b/stripe_terminal/ios/Classes/Api/ToApiExtensions.swift
@@ -606,7 +606,7 @@ extension Error {
 extension NSError {
     func toApi() -> PlatformError {
         guard self.scp_isAppleBuiltInReaderError else {
-            return PlatformError("", self.localizedDescription, "\(self)")
+            return PlatformError("\(self.code)", self.localizedDescription, "\(self)")
         }
         return PlatformError(self.toApiCode(), self.localizedDescription, "\(self)")
     }

--- a/stripe_terminal/ios/Classes/Plugin/DiscoveryDelegatePlugin.swift
+++ b/stripe_terminal/ios/Classes/Plugin/DiscoveryDelegatePlugin.swift
@@ -18,6 +18,7 @@ class DiscoveryDelegatePlugin: NSObject, DiscoveryDelegate {
     
     func terminal(_ terminal: Terminal, didUpdateDiscoveredReaders readers: [Reader]) {
         DispatchQueue.main.async {
+            self._readers = readers
             self._sink?.success(readers.map { $0.toApi() })
         }
     }

--- a/stripe_terminal/ios/Classes/StripeTerminalPlugin.swift
+++ b/stripe_terminal/ios/Classes/StripeTerminalPlugin.swift
@@ -45,7 +45,7 @@ public class StripeTerminalPlugin: NSObject, FlutterPlugin, StripeTerminalPlatfo
         Terminal.shared.clearCachedCredentials()
     }
 
-// Reader discovery, connection and updates
+// MARK: - Reader discovery, connection and updates
     private let _discoverReadersController: DiscoverReadersControllerApi
     private let _discoveryDelegate = DiscoveryDelegatePlugin()
     private var _readers: [Reader] { get {
@@ -191,7 +191,7 @@ public class StripeTerminalPlugin: NSObject, FlutterPlugin, StripeTerminalPlatfo
         }
     }
     
-// Taking payments
+// MARK: - Taking payments
     
     private var _paymentIntents: [String: PaymentIntent] = [:]
     
@@ -275,7 +275,7 @@ public class StripeTerminalPlugin: NSObject, FlutterPlugin, StripeTerminalPlatfo
         }
     }
     
-// Saving payment details for later use
+// MARK: - Saving payment details for later use
    
     private var _cancelablesReadReusableCard: [Int: Cancelable] = [:]
     private var _setupIntents: [String: SetupIntent] = [:]
@@ -385,7 +385,7 @@ public class StripeTerminalPlugin: NSObject, FlutterPlugin, StripeTerminalPlatfo
             throw error.toApi()
         }
     }
-// Card-present refunds
+// MARK: - Card-present refunds
     private var _cancelablesCollectRefundPaymentMethod: [Int: Cancelable] = [:]
 
     func onStartCollectRefundPaymentMethod(
@@ -432,7 +432,7 @@ public class StripeTerminalPlugin: NSObject, FlutterPlugin, StripeTerminalPlatfo
         }
     }
 
-// Display information to customers
+// MARK: - Display information to customers
     
     func onSetReaderDisplay(
         _ cart: CartApi
@@ -452,7 +452,7 @@ public class StripeTerminalPlugin: NSObject, FlutterPlugin, StripeTerminalPlatfo
         }
     }
     
-    // PRIVATE METHODS
+// MARK: - PRIVATE METHODS
     
     private func _clean() {
         if (Terminal.shared.connectedReader != nil) { Terminal.shared.disconnectReader  { error in } }


### PR DESCRIPTION
This is solving the last problem you are having on #8  