### PR TITLE
refactor(one_for_all_generator)!: the "Result" objects accept on `error` method a `PlatformError` class

### DIFF
--- a/one_for_all_generator/CHANGELOG.md
+++ b/one_for_all_generator/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next release
 - feat: support sealed classes
+- refactor!: renamed PlatformException to PlatformError
+- refactor!: the "Result" objects accept on `error` method a `PlatformError` class
 
 ## 1.0.1
 - fix: fixes `DateTime` swift serialization on swift code

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/Utils.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/Utils.kt
@@ -15,7 +15,7 @@ fun microsecondsToSeconds(value: Long): Int {
     return (value * 1000000).toInt()
 }
 
-fun createApiException(code: TerminalExceptionCodeApi, message: String? = null): TerminalExceptionApi {
+fun createApiError(code: TerminalExceptionCodeApi, message: String? = null): TerminalExceptionApi {
     return TerminalExceptionApi(
         code = code,
         message = message ?: "",

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/ToApiExtensions.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/ToApiExtensions.kt
@@ -3,14 +3,14 @@ package mek.stripeterminal.api
 import mek.stripeterminal.toHashMap
 import com.stripe.stripeterminal.external.models.*
 import com.stripe.stripeterminal.external.models.TerminalException.TerminalErrorCode
-import mek.stripeterminal.createApiException
+import mek.stripeterminal.createApiError
 
-fun TerminalException.toPlatformError(): PlatformException {
+fun TerminalException.toPlatformError(): PlatformError {
     return toApi().toPlatformError()
 }
 
-fun TerminalExceptionApi.toPlatformError(): PlatformException {
-    return PlatformException(
+fun TerminalExceptionApi.toPlatformError(): PlatformError {
+    return PlatformError(
         code = "mek_stripe_terminal",
         message = null,
         details = serialize()
@@ -19,7 +19,7 @@ fun TerminalExceptionApi.toPlatformError(): PlatformException {
 
 fun TerminalException.toApi(): TerminalExceptionApi {
     val code = errorCode.toApiCode()
-        ?: return createApiException(
+        ?: return createApiError(
             TerminalExceptionCodeApi.UNKNOWN,
             "Unsupported Terminal exception code: $errorCode"
         )

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/plugin/DiscoverReadersSubject.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/plugin/DiscoverReadersSubject.kt
@@ -11,8 +11,11 @@ import mek.stripeterminal.EmptyCallback
 import mek.stripeterminal.api.ControllerSink
 import mek.stripeterminal.api.DiscoveryConfigurationApi
 import mek.stripeterminal.api.ReaderApi
+import mek.stripeterminal.api.TerminalExceptionCodeApi
 import mek.stripeterminal.api.toApi
 import mek.stripeterminal.api.toHost
+import mek.stripeterminal.api.toPlatformError
+import mek.stripeterminal.createApiError
 import mek.stripeterminal.runOnMainThread
 
 class DiscoverReadersSubject {
@@ -30,7 +33,7 @@ class DiscoverReadersSubject {
     fun onListen(sink: ControllerSink<List<ReaderApi>>, configuration: DiscoveryConfigurationApi) {
         val hostConfiguration = configuration.toHost()
         if (hostConfiguration == null) {
-            sink.error("", "Discovery method not supported", null)
+            sink.error(createApiError(TerminalExceptionCodeApi.UNKNOWN, "Discovery method not supported").toPlatformError())
             sink.endOfStream()
             return
         }

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/plugin/TerminalDelegatePlugin.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/plugin/TerminalDelegatePlugin.kt
@@ -7,7 +7,6 @@ import com.stripe.stripeterminal.external.models.ConnectionStatus
 import com.stripe.stripeterminal.external.models.ConnectionTokenException
 import com.stripe.stripeterminal.external.models.PaymentStatus
 import com.stripe.stripeterminal.external.models.Reader
-import mek.stripeterminal.api.PlatformException
 import mek.stripeterminal.api.StripeTerminalHandlersApi
 import mek.stripeterminal.api.toApi
 import mek.stripeterminal.runOnMainThread
@@ -17,9 +16,8 @@ class TerminalDelegatePlugin(
 ) : ConnectionTokenProvider, TerminalListener {
 
     override fun fetchConnectionToken(callback: ConnectionTokenCallback) = runOnMainThread {
-        _handlers.requestConnectionToken({ code, message, details ->
-            val exception = PlatformException(code, message, details)
-            callback.onFailure(ConnectionTokenException("", exception))
+        _handlers.requestConnectionToken({ error ->
+            callback.onFailure(ConnectionTokenException(error.message ?: "", error))
         }, { token ->
             callback.onSuccess(token)
         })

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/plugin/TerminalErrorHandler.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/plugin/TerminalErrorHandler.kt
@@ -2,12 +2,13 @@ package mek.stripeterminal.plugin
 
 import com.stripe.stripeterminal.external.callable.ErrorCallback
 import com.stripe.stripeterminal.external.models.TerminalException
+import mek.stripeterminal.api.PlatformError
 import mek.stripeterminal.api.toPlatformError
 import mek.stripeterminal.runOnMainThread
 
-abstract class TerminalErrorHandler(private val handler: (c: String, m: String?, d: Any?) -> Unit) : ErrorCallback {
+abstract class TerminalErrorHandler(private val handler: (error: PlatformError) -> Unit) : ErrorCallback {
     override fun onFailure(e: TerminalException) {
-        val exception = e.toPlatformError()
-        runOnMainThread { handler(exception.code, exception.message, exception.details) }
+        val error = e.toPlatformError()
+        runOnMainThread { handler(error) }
     }
 }

--- a/stripe_terminal/ios/Classes/Plugin/DiscoveryDelegatePlugin.swift
+++ b/stripe_terminal/ios/Classes/Plugin/DiscoveryDelegatePlugin.swift
@@ -26,13 +26,15 @@ class DiscoveryDelegatePlugin: NSObject, DiscoveryDelegate {
     func onListen(
         _ sink: ControllerSink<[ReaderApi]>,
         _ configuration: DiscoveryConfigurationApi
-    ) -> FlutterError? {
+    ) -> PlatformError? {
         self._cancel()
         
         let configurationHost = try! configuration.toHost()
         guard let configurationHost else {
-            let exception = createApiException(TerminalExceptionCodeApi.unknown, "DiscoveryConfiguration not supported").toPlatformError()
-            return FlutterError(code: exception.code, message: exception.message, details: exception.details)
+            return createApiException(
+                TerminalExceptionCodeApi.unknown,
+                "DiscoveryConfiguration not supported"
+            ).toPlatformError()
         }
          
         self._cancelable = Terminal.shared.discoverReaders(
@@ -42,8 +44,7 @@ class DiscoveryDelegatePlugin: NSObject, DiscoveryDelegate {
             self._cancelable = nil
             DispatchQueue.main.async {
                 if let error = error as? NSError {
-                    let platformError = error.toPlatformError()
-                    self._sink?.error(platformError.code, platformError.message, platformError.details)
+                    self._sink?.error(error.toPlatformError())
                 }
                 
                 self._sink?.endOfStream()
@@ -54,7 +55,7 @@ class DiscoveryDelegatePlugin: NSObject, DiscoveryDelegate {
         return nil
     }
     
-    func onCancel(_ configuration: DiscoveryConfigurationApi) -> FlutterError? {
+    func onCancel(_ configuration: DiscoveryConfigurationApi) -> PlatformError? {
         self._cancel()
         return nil
     }

--- a/stripe_terminal/ios/Classes/StripeTerminalPlugin.swift
+++ b/stripe_terminal/ios/Classes/StripeTerminalPlugin.swift
@@ -230,8 +230,7 @@ public class StripeTerminalPlugin: NSObject, FlutterPlugin, StripeTerminalPlatfo
         self._cancelablesCollectPaymentMethod[operationId] = Terminal.shared.collectPaymentMethod(paymentIntent) { paymentIntent, error in
             self._cancelablesCollectPaymentMethod.removeValue(forKey: operationId)
             if let error = error as? NSError {
-                let platformError = error.toPlatformError()
-                result.error(platformError.code, platformError.message, platformError.details)
+                result.error(error.toPlatformError())
                 return
             }
             self._paymentIntents[paymentIntent!.stripeId!] = paymentIntent!
@@ -325,8 +324,7 @@ public class StripeTerminalPlugin: NSObject, FlutterPlugin, StripeTerminalPlatfo
             completion: { setupIntent, error in
                 self._cancelablesCollectSetupIntentPaymentMethod.removeValue(forKey: operationId)
                 if let error = error as? NSError {
-                    let platformError = error.toPlatformError()
-                    result.error(platformError.code, platformError.message, platformError.details)
+                    result.error(error.toPlatformError())
                     return
                 }
                 self._setupIntents[setupIntent!.stripeId] = setupIntent!
@@ -382,8 +380,7 @@ public class StripeTerminalPlugin: NSObject, FlutterPlugin, StripeTerminalPlatfo
             completion: { error in
                 self._cancelablesCollectRefundPaymentMethod.removeValue(forKey: operationId)
                 if let error = error as? NSError {
-                    let platformError = error.toPlatformError()
-                    result.error(platformError.code, platformError.message, platformError.details)
+                    result.error(error.toPlatformError())
                     return
                 }
                 result.success(())


### PR DESCRIPTION
refactor(one_for_all_generator)!: renamed PlatformException to PlatformError