### PR TITLE
refactor: Renamed `StripeTerminal` class to `Terminal`. 

### DIFF
--- a/one_for_all_generator/lib/src/generators/dart_api_builder.dart
+++ b/one_for_all_generator/lib/src/generators/dart_api_builder.dart
@@ -58,13 +58,13 @@ class DartApiBuilder extends ApiBuilder {
         ..static = true
         ..modifier = FieldModifier.constant
         ..name = '_\$channel'
-        ..assignment = Code('MethodChannel(\'${handler.channelName()}\')')))
+        ..assignment = Code('MethodChannel(\'${handler.methodChannelName()}\')')))
       ..fields.addAll(element.methods.where((e) => e.isHostApiEvent).map((e) {
         return Field((b) => b
           ..static = true
           ..modifier = FieldModifier.constant
           ..name = '_\$${e.name.no_}'
-          ..assignment = Code('EventChannel(\'${handler.controllerChannelName(e)}\')'));
+          ..assignment = Code('EventChannel(\'${handler.eventChannelName(e)}\')'));
       }))
       ..methods.addAll(element.methods.where((e) => e.isHostApiEvent).map((e) {
         final returnType = e.returnType.singleTypeArg;
@@ -86,7 +86,7 @@ class DartApiBuilder extends ApiBuilder {
 
         String parseResult() {
           final code =
-              'await _\$channel.invokeMethod(\'${handler.channelName(e)}\', [$parameters]);';
+              'await _\$channel.invokeMethod(\'${handler.methodChannelName(e)}\', [$parameters]);';
           if (returnType is VoidType) return code;
           return 'final result = $code'
               'return ${codecs.encodeDeserialization(returnType, 'result')};';
@@ -122,7 +122,7 @@ try {
         ..type = Reference(element.name)
         ..name = 'hostApi'))
       ..body = Code('''
-const channel = MethodChannel('${handler.channelName()}');
+const channel = MethodChannel('${handler.methodChannelName()}');
 channel.setMethodCallHandler((call) async {
   final args = call.arguments as List<Object?>;
   return switch (call.method) {

--- a/one_for_all_generator/lib/src/generators/kotlin_api_builder.dart
+++ b/one_for_all_generator/lib/src/generators/kotlin_api_builder.dart
@@ -209,7 +209,7 @@ ${methods.map((_) {
                     name: 'coroutineScope', type: 'CoroutineScope?', defaultTo: 'null'),
               ],
               body: '''
-channel = MethodChannel(binaryMessenger, "${handler.channelName()}")
+channel = MethodChannel(binaryMessenger, "${handler.methodChannelName()}")
 this.coroutineScope = coroutineScope ?: MainScope()
 channel.setMethodCallHandler(api::onMethodCall)''',
             ),
@@ -246,7 +246,7 @@ coroutineScope.cancel()''',
             visibility: KotlinVisibility.private,
             name: 'channel',
             type: 'EventChannel',
-            assignment: 'EventChannel(binaryMessenger, "${handler.controllerChannelName(e)}")',
+            assignment: 'EventChannel(binaryMessenger, "${handler.eventChannelName(e)}")',
           ),
         ],
         body: [
@@ -299,7 +299,7 @@ channel.setStreamHandler(object : EventChannel.StreamHandler {
           visibility: KotlinVisibility.private,
           name: 'channel',
           type: 'MethodChannel',
-          assignment: 'MethodChannel(binaryMessenger, "${handler.channelName()}")',
+          assignment: 'MethodChannel(binaryMessenger, "${handler.methodChannelName()}")',
         ),
       ],
       body: methods.map((_) {
@@ -336,7 +336,7 @@ channel.setStreamHandler(object : EventChannel.StreamHandler {
           body: switch (methodType) {
             MethodApiType.callbacks => '''
 channel.invokeMethod(
-    "${handler.channelName(e)}",
+    "${handler.methodChannelName(e)}",
     listOf<Any?>($parameters),
     object : MethodChannel.Result {
         override fun notImplemented() {}
@@ -347,11 +347,11 @@ channel.invokeMethod(
     }
 )''',
             MethodApiType.sync => '''
-channel.invokeMethod("${handler.channelName(e)}", listOf<Any?>($parameters))''',
+channel.invokeMethod("${handler.methodChannelName(e)}", listOf<Any?>($parameters))''',
             MethodApiType.async => '''
 return suspendCoroutine { continuation ->
     channel.invokeMethod(
-        "${handler.channelName(e)}",
+        "${handler.methodChannelName(e)}",
         listOf<Any?>($parameters),
         object : MethodChannel.Result {
             override fun notImplemented() {}

--- a/one_for_all_generator/lib/src/generators/swift_api_builder.dart
+++ b/one_for_all_generator/lib/src/generators/swift_api_builder.dart
@@ -224,7 +224,7 @@ class SwiftApiBuilder extends ApiBuilder {
         init: SwiftInit(
           parameters: [SwiftParameter(name: 'binaryMessenger', type: 'FlutterBinaryMessenger')],
           body:
-              'channel = FlutterEventChannel(name: "${handler.controllerChannelName(e)}", binaryMessenger: binaryMessenger)',
+              'channel = FlutterEventChannel(name: "${handler.eventChannelName(e)}", binaryMessenger: binaryMessenger)',
         ),
         fields: [
           SwiftField(
@@ -287,7 +287,7 @@ channel.setStreamHandler(ControllerHandler({ arguments, events in
         SwiftParameter(label: '_', name: 'hostApi', type: codecs.encodeName(element.name)),
       ],
       body: '''
-$channelVarAccess = FlutterMethodChannel(name: "${handler.channelName()}", binaryMessenger: binaryMessenger)
+$channelVarAccess = FlutterMethodChannel(name: "${handler.methodChannelName()}", binaryMessenger: binaryMessenger)
 $channelVarAccess!.setMethodCallHandler { call, result in
     let runAsync = { (function: @escaping () async throws -> Any?) -> Void in
         Task {
@@ -365,7 +365,7 @@ ${switch (methodType) {
         ),
       ], body: '''
 channel = FlutterMethodChannel(
-    name: "${handler.channelName()}",
+    name: "${handler.methodChannelName()}",
     binaryMessenger: binaryMessenger
 )'''),
       methods: methods.map((_) {
@@ -392,11 +392,11 @@ channel = FlutterMethodChannel(
             MethodApiType.callbacks => throw UnsupportedError(
                 'Not supported method ${MethodApiType.callbacks} on ${element.name}.${e.name}'),
             MethodApiType.sync => '''
-channel.invokeMethod("${handler.channelName(e)}", arguments: [$parameters])''',
+channel.invokeMethod("${handler.methodChannelName(e)}", arguments: [$parameters])''',
             MethodApiType.async => '''
 return try await withCheckedThrowingContinuation { continuation in
     DispatchQueue.main.async {
-        self.channel.invokeMethod("${handler.channelName(e)}", arguments: [$parameters]) { result in
+        self.channel.invokeMethod("${handler.methodChannelName(e)}", arguments: [$parameters]) { result in
             if let result = result as? FlutterError {
                 continuation.resume(throwing: PlatformError(result.code, result.message, result.details))
             } else {

--- a/one_for_all_generator/lib/src/handlers.dart
+++ b/one_for_all_generator/lib/src/handlers.dart
@@ -61,9 +61,8 @@ class HostApiHandler {
       .map((e) => MethodHandler.from(e, swiftMethod))
       .toList();
 
-  String channelName([MethodElement? e]) => e?.name ?? element.name;
-  String controllerChannelName(MethodElement? e) =>
-      '${element.name}${e != null ? '#${e.name}' : ''}';
+  String methodChannelName([MethodElement? e]) => e?.name ?? options.channelName(element.name);
+  String eventChannelName(MethodElement? e) => options.channelName(element.name, e?.name);
 }
 
 class FlutterApiHandler {
@@ -99,7 +98,7 @@ class FlutterApiHandler {
       .map((e) => MethodHandler.from(e, swiftMethod))
       .toList();
 
-  String channelName([MethodElement? e]) => e?.name ?? element.name;
+  String methodChannelName([MethodElement? e]) => e?.name ?? options.channelName(element.name);
 }
 
 sealed class SerializableHandler<T extends InterfaceElement> extends Equatable {

--- a/one_for_all_generator/lib/src/options.dart
+++ b/one_for_all_generator/lib/src/options.dart
@@ -3,15 +3,24 @@ import 'package:one_for_all_generator/one_for_all_generator.dart';
 class OneForAllOptions {
   final String apiFile;
   final List<String> extraApiFiles;
+  final String? packageName;
   final String hostClassSuffix;
   final List<ApiPlatformCodec> codecs;
 
   const OneForAllOptions({
     required this.apiFile,
     this.extraApiFiles = const [],
+    this.packageName,
     this.hostClassSuffix = '',
     this.codecs = const [],
   });
+
+  String channelName(String channel, [String? event]) {
+    var name = channel;
+    if (packageName != null) name = '$packageName#$name';
+    if (event != null) name = '$name#$event';
+    return name;
+  }
 }
 
 class DartOptions {

--- a/stripe_terminal/CHANGELOG.md
+++ b/stripe_terminal/CHANGELOG.md
@@ -1,3 +1,4 @@
+- refactor: Renamed `StripeTerminal` class to `Terminal`. The name has been aligned with the native SDKs.
 - docs: Added docs to all `TerminalExceptionCode` enum values
 - feat: Added to `TerminalException` class a updated `PaymentIntent` and `ApiError`
 - feat: Mapped all Android and IOS sdk errors to `TerminalExceptionCode` enum

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/TerminalPlugin.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/TerminalPlugin.kt
@@ -37,8 +37,8 @@ import mek.stripeterminal.api.LocationApi
 import mek.stripeterminal.api.PaymentIntentApi
 import mek.stripeterminal.api.ReaderApi
 import mek.stripeterminal.api.Result
-import mek.stripeterminal.api.StripeTerminalHandlersApi
-import mek.stripeterminal.api.StripeTerminalPlatformApi
+import mek.stripeterminal.api.TerminalHandlersApi
+import mek.stripeterminal.api.TerminalPlatformApi
 import mek.stripeterminal.api.toApi
 import mek.stripeterminal.api.toHost
 import mek.stripeterminal.plugin.ReaderDelegatePlugin
@@ -59,8 +59,8 @@ import mek.stripeterminal.api.toPlatformError
 import mek.stripeterminal.plugin.DiscoverReadersSubject
 import mek.stripeterminal.plugin.TerminalDelegatePlugin
 
-class StripeTerminalPlugin : FlutterPlugin, ActivityAware, StripeTerminalPlatformApi {
-    private lateinit var _handlers: StripeTerminalHandlersApi
+class TerminalPlugin : FlutterPlugin, ActivityAware, TerminalPlatformApi {
+    private lateinit var _handlers: TerminalHandlersApi
 
     private var _activity: Activity? = null
     private val permissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -554,8 +554,8 @@ class StripeTerminalPlugin : FlutterPlugin, ActivityAware, StripeTerminalPlatfor
 
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         val binaryMessenger = flutterPluginBinding.binaryMessenger
-        StripeTerminalPlatformApi.setHandler(binaryMessenger, this)
-        _handlers = StripeTerminalHandlersApi(binaryMessenger)
+        TerminalPlatformApi.setHandler(binaryMessenger, this)
+        _handlers = TerminalHandlersApi(binaryMessenger)
         _readerDelegate = ReaderDelegatePlugin(_handlers)
         _readerReconnectionDelegate = ReaderReconnectionListenerPlugin(_handlers)
 
@@ -566,7 +566,7 @@ class StripeTerminalPlugin : FlutterPlugin, ActivityAware, StripeTerminalPlatfor
         clean()
 
         _discoverReadersController.removeHandler()
-        StripeTerminalPlatformApi.removeHandler()
+        TerminalPlatformApi.removeHandler()
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/TerminalApi.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/TerminalApi.kt
@@ -53,7 +53,7 @@ class ControllerSink<T>(
     fun endOfStream() = sink.endOfStream()
 }
 
-interface StripeTerminalPlatformApi {
+interface TerminalPlatformApi {
     fun onInit(
         shouldPrintLogs: Boolean,
     )
@@ -379,10 +379,10 @@ interface StripeTerminalPlatformApi {
 
         fun setHandler(
             binaryMessenger: BinaryMessenger,
-            api: StripeTerminalPlatformApi,
+            api: TerminalPlatformApi,
             coroutineScope: CoroutineScope? = null,
         ) {
-            channel = MethodChannel(binaryMessenger, "StripeTerminalPlatform")
+            channel = MethodChannel(binaryMessenger, "mek_stripe_terminal#TerminalPlatform")
             this.coroutineScope = coroutineScope ?: MainScope()
             channel.setMethodCallHandler(api::onMethodCall)
         }
@@ -397,7 +397,7 @@ interface StripeTerminalPlatformApi {
 class DiscoverReadersControllerApi(
     binaryMessenger: BinaryMessenger,
 ) {
-    private val channel: EventChannel = EventChannel(binaryMessenger, "StripeTerminalPlatform#discoverReaders")
+    private val channel: EventChannel = EventChannel(binaryMessenger, "mek_stripe_terminal#TerminalPlatform#discoverReaders")
 
     fun setHandler(
         onListen: (sink: ControllerSink<List<ReaderApi>>, configuration: DiscoveryConfigurationApi) -> Unit,
@@ -416,10 +416,10 @@ class DiscoverReadersControllerApi(
     fun removeHandler() = channel.setStreamHandler(null)
 }
 
-class StripeTerminalHandlersApi(
+class TerminalHandlersApi(
     binaryMessenger: BinaryMessenger,
 ) {
-    private val channel: MethodChannel = MethodChannel(binaryMessenger, "StripeTerminalHandlers")
+    private val channel: MethodChannel = MethodChannel(binaryMessenger, "mek_stripe_terminal#TerminalHandlers")
 
     fun requestConnectionToken(
         onError: (error: PlatformError) -> Unit,

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/plugin/ReaderDelegatePlugin.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/plugin/ReaderDelegatePlugin.kt
@@ -9,11 +9,11 @@ import com.stripe.stripeterminal.external.models.ReaderEvent
 import com.stripe.stripeterminal.external.models.ReaderInputOptions
 import com.stripe.stripeterminal.external.models.ReaderSoftwareUpdate
 import com.stripe.stripeterminal.external.models.TerminalException
-import mek.stripeterminal.api.StripeTerminalHandlersApi
+import mek.stripeterminal.api.TerminalHandlersApi
 import mek.stripeterminal.api.toApi
 import mek.stripeterminal.runOnMainThread
 
-class ReaderDelegatePlugin(private val _handlers: StripeTerminalHandlersApi) :
+class ReaderDelegatePlugin(private val _handlers: TerminalHandlersApi) :
     ReaderListener, HandoffReaderListener {
     var cancelUpdate: Cancelable? = null
 

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/plugin/ReaderReconnectionDelegatePlugin.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/plugin/ReaderReconnectionDelegatePlugin.kt
@@ -3,11 +3,11 @@ package mek.stripeterminal.plugin
 import com.stripe.stripeterminal.external.callable.Cancelable
 import com.stripe.stripeterminal.external.callable.ReaderReconnectionListener
 import com.stripe.stripeterminal.external.models.Reader
-import mek.stripeterminal.api.StripeTerminalHandlersApi
+import mek.stripeterminal.api.TerminalHandlersApi
 import mek.stripeterminal.api.toApi
 import mek.stripeterminal.runOnMainThread
 
-class ReaderReconnectionListenerPlugin(private val _handlers: StripeTerminalHandlersApi) :
+class ReaderReconnectionListenerPlugin(private val _handlers: TerminalHandlersApi) :
     ReaderReconnectionListener {
     var cancelReconnect: Cancelable? = null
 

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/plugin/TerminalDelegatePlugin.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/plugin/TerminalDelegatePlugin.kt
@@ -7,12 +7,12 @@ import com.stripe.stripeterminal.external.models.ConnectionStatus
 import com.stripe.stripeterminal.external.models.ConnectionTokenException
 import com.stripe.stripeterminal.external.models.PaymentStatus
 import com.stripe.stripeterminal.external.models.Reader
-import mek.stripeterminal.api.StripeTerminalHandlersApi
+import mek.stripeterminal.api.TerminalHandlersApi
 import mek.stripeterminal.api.toApi
 import mek.stripeterminal.runOnMainThread
 
 class TerminalDelegatePlugin(
-    private val _handlers: StripeTerminalHandlersApi
+    private val _handlers: TerminalHandlersApi
 ) : ConnectionTokenProvider, TerminalListener {
 
     override fun fetchConnectionToken(callback: ConnectionTokenCallback) = runOnMainThread {

--- a/stripe_terminal/android/src/test/kotlin/mek/stripeterminal/StripeTerminalPluginTest.kt
+++ b/stripe_terminal/android/src/test/kotlin/mek/stripeterminal/StripeTerminalPluginTest.kt
@@ -16,7 +16,7 @@ import org.mockito.Mockito
 internal class StripeTerminalPluginTest {
   @Test
   fun onMethodCall_getPlatformVersion_returnsExpectedValue() {
-    val plugin = StripeTerminalPlugin()
+    val plugin = TerminalPlugin()
 
     val call = MethodCall("getPlatformVersion", null)
     val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)

--- a/stripe_terminal/ios/Classes/Api/TerminalApi.swift
+++ b/stripe_terminal/ios/Classes/Api/TerminalApi.swift
@@ -90,7 +90,7 @@ class ControllerHandler: NSObject, FlutterStreamHandler {
     ) -> FlutterError? { _onCancel(arguments)?.toFlutterError() }
 }
 
-protocol StripeTerminalPlatformApi {
+protocol TerminalPlatformApi {
     func onInit(
         _ shouldPrintLogs: Bool
     ) async throws -> Void
@@ -238,7 +238,7 @@ class DiscoverReadersControllerApi {
     init(
         binaryMessenger: FlutterBinaryMessenger
     ) {
-        channel = FlutterEventChannel(name: "StripeTerminalPlatform#discoverReaders", binaryMessenger: binaryMessenger)
+        channel = FlutterEventChannel(name: "mek_stripe_terminal#TerminalPlatform#discoverReaders", binaryMessenger: binaryMessenger)
     }
 
     func setHandler(
@@ -258,14 +258,14 @@ class DiscoverReadersControllerApi {
     func removeHandler() { channel.setStreamHandler(nil) }
 }
 
-private var channelStripeTerminalPlatformApi: FlutterMethodChannel? = nil
+private var channelTerminalPlatformApi: FlutterMethodChannel? = nil
 
-func setStripeTerminalPlatformApiHandler(
+func setTerminalPlatformApiHandler(
     _ binaryMessenger: FlutterBinaryMessenger,
-    _ hostApi: StripeTerminalPlatformApi
+    _ hostApi: TerminalPlatformApi
 ) {
-    channelStripeTerminalPlatformApi = FlutterMethodChannel(name: "StripeTerminalPlatform", binaryMessenger: binaryMessenger)
-    channelStripeTerminalPlatformApi!.setMethodCallHandler { call, result in
+    channelTerminalPlatformApi = FlutterMethodChannel(name: "mek_stripe_terminal#TerminalPlatform", binaryMessenger: binaryMessenger)
+    channelTerminalPlatformApi!.setMethodCallHandler { call, result in
         let runAsync = { (function: @escaping () async throws -> Any?) -> Void in
             Task {
                 do {
@@ -441,18 +441,18 @@ func setStripeTerminalPlatformApiHandler(
     }
 }
 
-func removeStripeTerminalPlatformApiHandler() {
-    channelStripeTerminalPlatformApi?.setMethodCallHandler(nil)
+func removeTerminalPlatformApiHandler() {
+    channelTerminalPlatformApi?.setMethodCallHandler(nil)
 }
 
-class StripeTerminalHandlersApi {
+class TerminalHandlersApi {
     let channel: FlutterMethodChannel
 
     init(
         _ binaryMessenger: FlutterBinaryMessenger
     ) {
         channel = FlutterMethodChannel(
-            name: "StripeTerminalHandlers",
+            name: "mek_stripe_terminal#TerminalHandlers",
             binaryMessenger: binaryMessenger
         )
     }

--- a/stripe_terminal/ios/Classes/Plugin/ReaderDelegatePlugin.swift
+++ b/stripe_terminal/ios/Classes/Plugin/ReaderDelegatePlugin.swift
@@ -2,10 +2,10 @@ import Foundation
 import StripeTerminal
 
 class ReaderDelegatePlugin: NSObject, BluetoothReaderDelegate, LocalMobileReaderDelegate {
-    private let _handlers: StripeTerminalHandlersApi
+    private let _handlers: TerminalHandlersApi
     var cancellableUpdate: Cancelable?
 
-    init(_ handlers: StripeTerminalHandlersApi) {
+    init(_ handlers: TerminalHandlersApi) {
         self._handlers = handlers
     }
     

--- a/stripe_terminal/ios/Classes/Plugin/ReaderReconnectionDelegatePlugin.swift
+++ b/stripe_terminal/ios/Classes/Plugin/ReaderReconnectionDelegatePlugin.swift
@@ -2,10 +2,10 @@ import Foundation
 import StripeTerminal
 
 class ReaderReconnectionDelegatePlugin: NSObject, ReconnectionDelegate {
-    private let _handlers: StripeTerminalHandlersApi
+    private let _handlers: TerminalHandlersApi
     var cancelable: Cancelable?
 
-    init(_ handlers: StripeTerminalHandlersApi) {
+    init(_ handlers: TerminalHandlersApi) {
         self._handlers = handlers
     }
 

--- a/stripe_terminal/ios/Classes/Plugin/TerminalDelegatePlugin.swift
+++ b/stripe_terminal/ios/Classes/Plugin/TerminalDelegatePlugin.swift
@@ -2,9 +2,9 @@ import Foundation
 import StripeTerminal
 
 class TerminalDelegatePlugin: NSObject, ConnectionTokenProvider, TerminalDelegate {
-    private let handlers: StripeTerminalHandlersApi
+    private let handlers: TerminalHandlersApi
 
-    init(_ handlers: StripeTerminalHandlersApi) {
+    init(_ handlers: TerminalHandlersApi) {
         self.handlers = handlers
     }
     

--- a/stripe_terminal/ios/Classes/TerminalPlugin.swift
+++ b/stripe_terminal/ios/Classes/TerminalPlugin.swift
@@ -2,17 +2,17 @@ import Flutter
 import StripeTerminal
 import UIKit
 
-public class StripeTerminalPlugin: NSObject, FlutterPlugin, StripeTerminalPlatformApi {
+public class TerminalPlugin: NSObject, FlutterPlugin, TerminalPlatformApi {
     public static func register(with registrar: FlutterPluginRegistrar) {
-        let instance = StripeTerminalPlugin(registrar.messenger())
-        setStripeTerminalPlatformApiHandler(registrar.messenger(), instance)
+        let instance = TerminalPlugin(registrar.messenger())
+        setTerminalPlatformApiHandler(registrar.messenger(), instance)
         instance.onAttachedToEngine()
     }
     
-    private let handlers: StripeTerminalHandlersApi
+    private let handlers: TerminalHandlersApi
 
     init(_ binaryMessenger: FlutterBinaryMessenger) {
-        self.handlers = StripeTerminalHandlersApi(binaryMessenger)
+        self.handlers = TerminalHandlersApi(binaryMessenger)
         self._discoverReadersController = DiscoverReadersControllerApi(binaryMessenger: binaryMessenger)
         self._readerDelegate = ReaderDelegatePlugin(handlers)
         self._readerReconnectionDelegate = ReaderReconnectionDelegatePlugin(handlers)
@@ -24,7 +24,7 @@ public class StripeTerminalPlugin: NSObject, FlutterPlugin, StripeTerminalPlatfo
     
     public func detachFromEngine(for registrar: FlutterPluginRegistrar) {
         self._discoverReadersController.removeHandler()
-        removeStripeTerminalPlatformApiHandler()
+        removeTerminalPlatformApiHandler()
         self._clean()
     }
     

--- a/stripe_terminal/lib/mek_stripe_terminal.dart
+++ b/stripe_terminal/lib/mek_stripe_terminal.dart
@@ -14,5 +14,5 @@ export 'src/models/reader_software_update.dart';
 export 'src/models/refund.dart';
 export 'src/models/setup_intent.dart';
 export 'src/reader_delegates.dart';
-export 'src/stripe_terminal.dart';
+export 'src/terminal.dart';
 export 'src/terminal_exception.dart';

--- a/stripe_terminal/lib/src/models/payment_intent.dart
+++ b/stripe_terminal/lib/src/models/payment_intent.dart
@@ -43,7 +43,7 @@ class PaymentIntent with _$PaymentIntent {
   /// This is only non-null in the [PaymentIntent] instance returned during collect when using
   /// updatePaymentIntent set to true in the CollectConfiguration.
   ///
-  /// After [StripeTerminal.confirmPaymentIntent] the amount will have this tip amount added
+  /// After [Terminal.confirmPaymentIntent] the amount will have this tip amount added
   /// to it and the [amountDetails] will contain the breakdown of how much of the amount was a tip.
   final double? amountTip;
 
@@ -160,10 +160,10 @@ enum PaymentIntentStatus {
   /// Next step: capture the [PaymentIntent] on your backend via the Stripe API.
   requiresCapture,
 
-  /// Next step: confirm the payment by calling [StripeTerminal.confirmPaymentIntent].
+  /// Next step: confirm the payment by calling [Terminal.confirmPaymentIntent].
   requiresConfirmation,
 
-  /// Next step: collect a payment method by calling [StripeTerminal.collectPaymentMethod].
+  /// Next step: collect a payment method by calling [Terminal.collectPaymentMethod].
   requiresPaymentMethod,
 
   /// The [PaymentIntent] succeeded.

--- a/stripe_terminal/lib/src/models/reader.dart
+++ b/stripe_terminal/lib/src/models/reader.dart
@@ -51,7 +51,7 @@ class Reader with _$Reader {
   /// Bluetooth and Apple Built-In readers are designed to be more mobile and must be registered
   /// to a location upon each connection. This field represents the last location that the reader
   /// was registered to. If the reader has not been used before, this field will be `null`. If you
-  /// associate the reader to a different location while calling [StripeTerminal.connectBluetoothReader],
+  /// associate the reader to a different location while calling [Terminal.connectBluetoothReader],
   /// this field will update to that new location’s id.
   final String? locationId;
 
@@ -69,9 +69,9 @@ class Reader with _$Reader {
   /// The available update for this reader, or nil if no update is available. This update will also
   /// have been announced via [PhysicalReaderDelegate.onReportAvailableUpdate]
   ///
-  /// Install this update with [StripeTerminal.installAvailableUpdate]
+  /// Install this update with [Terminal.installAvailableUpdate]
   ///
-  /// calls to [StripeTerminal.installAvailableUpdate] when availableUpdate is `null` will result in
+  /// calls to [Terminal.installAvailableUpdate] when availableUpdate is `null` will result in
   /// [PhysicalReaderDelegate.onFinishInstallingUpdate] called immediately with a `null` update and `null` error.
   final bool availableUpdate;
 

--- a/stripe_terminal/lib/src/models/setup_intent.dart
+++ b/stripe_terminal/lib/src/models/setup_intent.dart
@@ -85,6 +85,7 @@ class SetupAttempt with _$SetupAttempt {
   final String? customerId;
 
   /// (Connect) The account (if any) for which the setup is intended.
+  // TODO: Rename to onBehalfOf
   final String? onBehalfOfId;
 
   /// ID of the payment method used with this SetupAttempt.

--- a/stripe_terminal/lib/src/platform/terminal_handlers.dart
+++ b/stripe_terminal/lib/src/platform/terminal_handlers.dart
@@ -1,8 +1,8 @@
-part of 'stripe_terminal_platform.dart';
+part of 'terminal_platform.dart';
 
 @FlutterApi()
-class StripeTerminalHandlers {
-  final StripeTerminalPlatform _platform;
+class TerminalHandlers {
+  final TerminalPlatform _platform;
   final Future<String> Function() _fetchToken;
 
   final _unexpectedReaderDisconnectController = StreamController<Reader>.broadcast();
@@ -18,12 +18,12 @@ class StripeTerminalHandlers {
       _connectionStatusChangeController.stream;
   Stream<PaymentStatus> get paymentStatusChangeStream => _paymentStatusChangeController.stream;
 
-  StripeTerminalHandlers({
-    required StripeTerminalPlatform platform,
+  TerminalHandlers({
+    required TerminalPlatform platform,
     required Future<String> Function() fetchToken,
   })  : _platform = platform,
         _fetchToken = fetchToken {
-    _$setupStripeTerminalHandlers(this);
+    _$setupTerminalHandlers(this);
   }
 
   void attachReaderDelegates(

--- a/stripe_terminal/lib/src/platform/terminal_platform.api.dart
+++ b/stripe_terminal/lib/src/platform/terminal_platform.api.dart
@@ -2,12 +2,13 @@
 
 // ignore_for_file: unused_element
 
-part of 'stripe_terminal_platform.dart';
+part of 'terminal_platform.dart';
 
-class _$StripeTerminalPlatform {
-  static const _$channel = MethodChannel('StripeTerminalPlatform');
+class _$TerminalPlatform {
+  static const _$channel = MethodChannel('mek_stripe_terminal#TerminalPlatform');
 
-  static const _$discoverReaders = EventChannel('StripeTerminalPlatform#discoverReaders');
+  static const _$discoverReaders =
+      EventChannel('mek_stripe_terminal#TerminalPlatform#discoverReaders');
 
   Stream<List<Reader>> discoverReaders(DiscoveryConfiguration configuration) {
     return _$discoverReaders
@@ -19,7 +20,7 @@ class _$StripeTerminalPlatform {
     try {
       await _$channel.invokeMethod('init', [shouldPrintLogs]);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -28,7 +29,7 @@ class _$StripeTerminalPlatform {
     try {
       await _$channel.invokeMethod('clearCachedCredentials', []);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -38,7 +39,7 @@ class _$StripeTerminalPlatform {
       final result = await _$channel.invokeMethod('getConnectionStatus', []);
       return ConnectionStatus.values[result as int];
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -52,7 +53,7 @@ class _$StripeTerminalPlatform {
           [deviceType.index, _$serializeDiscoveryConfiguration(discoveryConfiguration)]);
       return result as bool;
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -67,7 +68,7 @@ class _$StripeTerminalPlatform {
           [serialNumber, locationId, autoReconnectOnUnexpectedDisconnect]);
       return _$deserializeReader(result as List);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -77,7 +78,7 @@ class _$StripeTerminalPlatform {
       final result = await _$channel.invokeMethod('connectHandoffReader', [serialNumber]);
       return _$deserializeReader(result as List);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -91,7 +92,7 @@ class _$StripeTerminalPlatform {
           await _$channel.invokeMethod('connectInternetReader', [serialNumber, failIfInUse]);
       return _$deserializeReader(result as List);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -105,7 +106,7 @@ class _$StripeTerminalPlatform {
           await _$channel.invokeMethod('connectMobileReader', [serialNumber, locationId]);
       return _$deserializeReader(result as List);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -120,7 +121,7 @@ class _$StripeTerminalPlatform {
           'connectUsbReader', [serialNumber, locationId, autoReconnectOnUnexpectedDisconnect]);
       return _$deserializeReader(result as List);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -130,7 +131,7 @@ class _$StripeTerminalPlatform {
       final result = await _$channel.invokeMethod('getConnectedReader', []);
       return result != null ? _$deserializeReader(result as List) : null;
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -139,7 +140,7 @@ class _$StripeTerminalPlatform {
     try {
       await _$channel.invokeMethod('cancelReaderReconnection', []);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -154,7 +155,7 @@ class _$StripeTerminalPlatform {
           await _$channel.invokeMethod('listLocations', [endingBefore, limit, startingAfter]);
       return (result as List).map((e) => _$deserializeLocation(e as List)).toList();
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -163,7 +164,7 @@ class _$StripeTerminalPlatform {
     try {
       await _$channel.invokeMethod('installAvailableUpdate', []);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -172,7 +173,7 @@ class _$StripeTerminalPlatform {
     try {
       await _$channel.invokeMethod('cancelReaderUpdate', []);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -181,7 +182,7 @@ class _$StripeTerminalPlatform {
     try {
       await _$channel.invokeMethod('disconnectReader', []);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -191,7 +192,7 @@ class _$StripeTerminalPlatform {
       final result = await _$channel.invokeMethod('getPaymentStatus', []);
       return PaymentStatus.values[result as int];
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -202,7 +203,7 @@ class _$StripeTerminalPlatform {
           .invokeMethod('createPaymentIntent', [_$serializePaymentIntentParameters(parameters)]);
       return _$deserializePaymentIntent(result as List);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -212,7 +213,7 @@ class _$StripeTerminalPlatform {
       final result = await _$channel.invokeMethod('retrievePaymentIntent', [clientSecret]);
       return _$deserializePaymentIntent(result as List);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -227,7 +228,7 @@ class _$StripeTerminalPlatform {
           .invokeMethod('startCollectPaymentMethod', [operationId, paymentIntentId, skipTipping]);
       return _$deserializePaymentIntent(result as List);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -236,7 +237,7 @@ class _$StripeTerminalPlatform {
     try {
       await _$channel.invokeMethod('stopCollectPaymentMethod', [operationId]);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -246,7 +247,7 @@ class _$StripeTerminalPlatform {
       final result = await _$channel.invokeMethod('confirmPaymentIntent', [paymentIntentId]);
       return _$deserializePaymentIntent(result as List);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -256,7 +257,7 @@ class _$StripeTerminalPlatform {
       final result = await _$channel.invokeMethod('cancelPaymentIntent', [paymentIntentId]);
       return _$deserializePaymentIntent(result as List);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -278,7 +279,7 @@ class _$StripeTerminalPlatform {
       ]);
       return _$deserializeSetupIntent(result as List);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -288,7 +289,7 @@ class _$StripeTerminalPlatform {
       final result = await _$channel.invokeMethod('retrieveSetupIntent', [clientSecret]);
       return _$deserializeSetupIntent(result as List);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -304,7 +305,7 @@ class _$StripeTerminalPlatform {
           [operationId, setupIntentId, customerConsentCollected, isCustomerCancellationEnabled]);
       return _$deserializeSetupIntent(result as List);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -313,7 +314,7 @@ class _$StripeTerminalPlatform {
     try {
       await _$channel.invokeMethod('stopCollectSetupIntentPaymentMethod', [operationId]);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -323,7 +324,7 @@ class _$StripeTerminalPlatform {
       final result = await _$channel.invokeMethod('confirmSetupIntent', [setupIntentId]);
       return _$deserializeSetupIntent(result as List);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -333,7 +334,7 @@ class _$StripeTerminalPlatform {
       final result = await _$channel.invokeMethod('cancelSetupIntent', [setupIntentId]);
       return _$deserializeSetupIntent(result as List);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -360,7 +361,7 @@ class _$StripeTerminalPlatform {
         isCustomerCancellationEnabled
       ]);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -369,7 +370,7 @@ class _$StripeTerminalPlatform {
     try {
       await _$channel.invokeMethod('stopCollectRefundPaymentMethod', [operationId]);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -379,7 +380,7 @@ class _$StripeTerminalPlatform {
       final result = await _$channel.invokeMethod('confirmRefund', []);
       return _$deserializeRefund(result as List);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -388,7 +389,7 @@ class _$StripeTerminalPlatform {
     try {
       await _$channel.invokeMethod('setReaderDisplay', [_$serializeCart(cart)]);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
@@ -397,14 +398,14 @@ class _$StripeTerminalPlatform {
     try {
       await _$channel.invokeMethod('clearReaderDisplay', []);
     } on PlatformException catch (exception) {
-      StripeTerminalPlatform._throwIfIsHostException(exception);
+      TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
     }
   }
 }
 
-void _$setupStripeTerminalHandlers(StripeTerminalHandlers hostApi) {
-  const channel = MethodChannel('StripeTerminalHandlers');
+void _$setupTerminalHandlers(TerminalHandlers hostApi) {
+  const channel = MethodChannel('mek_stripe_terminal#TerminalHandlers');
   channel.setMethodCallHandler((call) async {
     final args = call.arguments as List<Object?>;
     return switch (call.method) {
@@ -438,7 +439,7 @@ void _$setupStripeTerminalHandlers(StripeTerminalHandlers hostApi) {
         hostApi._onReaderReconnectStarted(_$deserializeReader(args[0] as List)),
       '_onReaderReconnectSucceeded' =>
         hostApi._onReaderReconnectSucceeded(_$deserializeReader(args[0] as List)),
-      _ => throw UnsupportedError('StripeTerminalHandlers#Flutter.${call.method} method'),
+      _ => throw UnsupportedError('TerminalHandlers#Flutter.${call.method} method'),
     };
   });
 }

--- a/stripe_terminal/lib/src/platform/terminal_platform.dart
+++ b/stripe_terminal/lib/src/platform/terminal_platform.dart
@@ -17,15 +17,15 @@ import 'package:mek_stripe_terminal/src/reader_delegates.dart';
 import 'package:mek_stripe_terminal/src/terminal_exception.dart';
 import 'package:one_for_all/one_for_all.dart';
 
-part 'stripe_terminal_handlers.dart';
-part 'stripe_terminal_platform.api.dart';
+part 'terminal_handlers.dart';
+part 'terminal_platform.api.dart';
 
 @HostApi(
-  hostExceptionHandler: StripeTerminalPlatform._throwIfIsHostException,
+  hostExceptionHandler: TerminalPlatform._throwIfIsHostException,
   kotlinMethod: MethodApiType.callbacks,
   swiftMethod: MethodApiType.async,
 )
-class StripeTerminalPlatform extends _$StripeTerminalPlatform {
+class TerminalPlatform extends _$TerminalPlatform {
   @MethodApi(kotlin: MethodApiType.sync)
   @override
   Future<void> init({required bool shouldPrintLogs});

--- a/stripe_terminal/lib/src/terminal.dart
+++ b/stripe_terminal/lib/src/terminal.dart
@@ -11,24 +11,27 @@ import 'package:mek_stripe_terminal/src/models/payment_intent.dart';
 import 'package:mek_stripe_terminal/src/models/reader.dart';
 import 'package:mek_stripe_terminal/src/models/refund.dart';
 import 'package:mek_stripe_terminal/src/models/setup_intent.dart';
-import 'package:mek_stripe_terminal/src/platform/stripe_terminal_platform.dart';
+import 'package:mek_stripe_terminal/src/platform/terminal_platform.dart';
 import 'package:mek_stripe_terminal/src/reader_delegates.dart';
 
+@Deprecated('Use Terminal. The name has been aligned with the native SDKs.')
+typedef StripeTerminal = Terminal;
+
 /// Parts documented with "???" are not yet validated
-class StripeTerminal {
-  static final _platformInstance = StripeTerminalPlatform();
-  static StripeTerminalHandlers? _handlersInstance;
+class Terminal {
+  static final _platformInstance = TerminalPlatform();
+  static TerminalHandlers? _handlersInstance;
 
-  static Future<StripeTerminal>? _instance;
+  static Future<Terminal>? _instance;
 
-  final StripeTerminalPlatform _platform;
-  final StripeTerminalHandlers _handlers;
+  final TerminalPlatform _platform;
+  final TerminalHandlers _handlers;
 
   /// Creates an internal `StripeTerminal` instance
-  StripeTerminal._(this._platform, this._handlers);
+  Terminal._(this._platform, this._handlers);
 
   /// Initializes the terminal SDK
-  static Future<StripeTerminal> getInstance({
+  static Future<Terminal> getInstance({
     bool shouldPrintLogs = false,
 
     /// A callback function that returns a Future which resolves to a connection token from your backend
@@ -36,7 +39,7 @@ class StripeTerminal {
     required Future<String> Function() fetchToken,
   }) {
     final platform = _platformInstance;
-    final handlers = _handlersInstance ??= StripeTerminalHandlers(
+    final handlers = _handlersInstance ??= TerminalHandlers(
       platform: platform,
       fetchToken: fetchToken,
     );
@@ -44,7 +47,7 @@ class StripeTerminal {
     return _instance ??= (() async {
       try {
         await platform.init(shouldPrintLogs: shouldPrintLogs);
-        return StripeTerminal._(platform, handlers);
+        return Terminal._(platform, handlers);
       } catch (_) {
         _instance = null;
         rethrow;

--- a/stripe_terminal/pubspec.yaml
+++ b/stripe_terminal/pubspec.yaml
@@ -68,9 +68,9 @@ flutter:
     platforms:
       android:
         package: mek.stripeterminal
-        pluginClass: StripeTerminalPlugin
+        pluginClass: TerminalPlugin
       ios:
-        pluginClass: StripeTerminalPlugin
+        pluginClass: TerminalPlugin
 
   # To add assets to your plugin package, add an assets section, like this:
   # assets:

--- a/stripe_terminal/tool/generate_api.dart
+++ b/stripe_terminal/tool/generate_api.dart
@@ -3,11 +3,12 @@ import 'package:one_for_all_generator/one_for_all_generator.dart';
 void main() async {
   await OneForAll.from(
     options: const OneForAllOptions(
-      apiFile: 'lib/src/platform/stripe_terminal_platform.dart',
+      apiFile: 'lib/src/platform/terminal_platform.dart',
       extraApiFiles: [
         'lib/src/terminal_exception.dart',
       ],
       hostClassSuffix: 'Api',
+      packageName: 'mek_stripe_terminal',
       codecs: ApiPlatformCodec.values,
     ),
     dartOptions: const DartOptions(
@@ -15,10 +16,10 @@ void main() async {
     ),
     kotlinOptions: const KotlinOptions(
       package: 'mek.stripeterminal.api',
-      outputFile: 'android/src/main/kotlin/mek/stripeterminal/api/StripeTerminalApi.kt',
+      outputFile: 'android/src/main/kotlin/mek/stripeterminal/api/TerminalApi.kt',
     ),
     swiftOptions: const SwiftOptions(
-      outputFile: 'ios/Classes/Api/StripeTerminalApi.swift',
+      outputFile: 'ios/Classes/Api/TerminalApi.swift',
     ),
   ).build();
 }


### PR DESCRIPTION
The name has been aligned with the native SDKs.