### PR TITLE
Align models fields names and types

### DIFF
--- a/stripe_terminal/CHANGELOG.md
+++ b/stripe_terminal/CHANGELOG.md
@@ -4,6 +4,13 @@
 - feat: Mapped all Android and IOS sdk errors to `TerminalExceptionCode` enum
 
 *BREAKING CHANGES*
+- refactor: Now `PaymentIntent.captureMethod` is a Enum `CaptureMethod`
+- refactor: Now `PaymentIntent.confirmationMethod` is a Enum `ConfirmationMethod`
+- refactor: Now `PaymentIntent.setupFutureUsage` is a Enum `PaymentIntentUsage`
+- refactor: Renamed on `PaymentIntent`: `application` to `applicationId`, `customer` to `customerId`, `invoice` to `invoiceId`, `review` to `reviewId`
+- fix: Added support on `PaymentIntentStatus` to `requiresAction` value
+- refactor: Now `PaymentIntentParameters.setupFutureUsage` is a Enum `PaymentIntentUsage`
+- refactor: Renamed on `SetupAttempt`: `onBehalfOfId` to `onBehalfOf`
 - refactor: Removed `TerminalException.rawCode` in favour of `TerminalException.code` enum field
 
 ## 3.0.0-dev.1

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/TerminalApi.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/TerminalApi.kt
@@ -676,6 +676,10 @@ data class CartLineItemApi(
     }
 }
 
+enum class ConfirmationMethodApi {
+    AUTOMATIC, MANUAL;
+}
+
 enum class ConnectionStatusApi {
     NOT_CONNECTED, CONNECTED, CONNECTING;
 }
@@ -820,7 +824,7 @@ data class PaymentIntentApi(
     val created: Long,
     val status: PaymentIntentStatusApi,
     val amount: Double,
-    val captureMethod: String,
+    val captureMethod: CaptureMethodApi,
     val currency: String,
     val metadata: HashMap<String, String>,
     val paymentMethodId: String?,
@@ -829,19 +833,19 @@ data class PaymentIntentApi(
     val statementDescriptorSuffix: String?,
     val amountCapturable: Double?,
     val amountReceived: Double?,
-    val application: String?,
+    val applicationId: String?,
     val applicationFeeAmount: Double?,
     val cancellationReason: String?,
     val canceledAt: Long?,
     val clientSecret: String?,
-    val confirmationMethod: String?,
-    val customer: String?,
+    val confirmationMethod: ConfirmationMethodApi?,
+    val customerId: String?,
     val description: String?,
-    val invoice: String?,
+    val invoiceId: String?,
     val onBehalfOf: String?,
-    val review: String?,
+    val reviewId: String?,
     val receiptEmail: String?,
-    val setupFutureUsage: String?,
+    val setupFutureUsage: PaymentIntentUsageApi?,
     val transferGroup: String?,
 ) {
     fun serialize(): List<Any?> {
@@ -850,7 +854,7 @@ data class PaymentIntentApi(
             created,
             status.ordinal,
             amount,
-            captureMethod,
+            captureMethod.ordinal,
             currency,
             hashMapOf(*metadata.map { (k, v) -> k to v }.toTypedArray()),
             paymentMethodId,
@@ -859,19 +863,19 @@ data class PaymentIntentApi(
             statementDescriptorSuffix,
             amountCapturable,
             amountReceived,
-            application,
+            applicationId,
             applicationFeeAmount,
             cancellationReason,
             canceledAt,
             clientSecret,
-            confirmationMethod,
-            customer,
+            confirmationMethod?.ordinal,
+            customerId,
             description,
-            invoice,
+            invoiceId,
             onBehalfOf,
-            review,
+            reviewId,
             receiptEmail,
-            setupFutureUsage,
+            setupFutureUsage?.ordinal,
             transferGroup,
         )
     }
@@ -892,7 +896,7 @@ data class PaymentIntentParametersApi(
     val transferDataDestination: String?,
     val transferGroup: String?,
     val onBehalfOf: String?,
-    val setupFutureUsage: String?,
+    val setupFutureUsage: PaymentIntentUsageApi?,
     val paymentMethodOptionsParameters: PaymentMethodOptionsParametersApi?,
 ) {
     companion object {
@@ -914,7 +918,7 @@ data class PaymentIntentParametersApi(
                 transferDataDestination = serialized[11] as String?,
                 transferGroup = serialized[12] as String?,
                 onBehalfOf = serialized[13] as String?,
-                setupFutureUsage = serialized[14] as String?,
+                setupFutureUsage = (serialized[14] as Int?)?.let { PaymentIntentUsageApi.values()[it] },
                 paymentMethodOptionsParameters = (serialized[15] as List<Any?>?)?.let { PaymentMethodOptionsParametersApi.deserialize(it) },
             )
         }
@@ -922,7 +926,11 @@ data class PaymentIntentParametersApi(
 }
 
 enum class PaymentIntentStatusApi {
-    CANCELED, PROCESSING, REQUIRES_CAPTURE, REQUIRES_CONFIRMATION, REQUIRES_PAYMENT_METHOD, SUCCEEDED;
+    CANCELED, PROCESSING, REQUIRES_CAPTURE, REQUIRES_CONFIRMATION, REQUIRES_PAYMENT_METHOD, REQUIRES_ACTION, SUCCEEDED;
+}
+
+enum class PaymentIntentUsageApi {
+    ON_SESSION, OFF_SESSION;
 }
 
 data class PaymentMethodDetailsApi(
@@ -1080,7 +1088,7 @@ data class SetupAttemptApi(
     val applicationId: String?,
     val created: Long,
     val customerId: String?,
-    val onBehalfOfId: String?,
+    val onBehalfOf: String?,
     val paymentMethodId: String?,
     val paymentMethodDetails: SetupAttemptPaymentMethodDetailsApi?,
     val setupIntentId: String,
@@ -1092,7 +1100,7 @@ data class SetupAttemptApi(
             applicationId,
             created,
             customerId,
-            onBehalfOfId,
+            onBehalfOf,
             paymentMethodId,
             paymentMethodDetails?.serialize(),
             setupIntentId,

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/ToApiExtensions.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/ToApiExtensions.kt
@@ -24,12 +24,12 @@ fun TerminalException.toApi(): TerminalExceptionApi {
             "Unsupported Terminal exception code: $errorCode"
         )
     return TerminalExceptionApi(
-            code = code,
-            message = errorMessage,
-            stackTrace  = stackTraceToString(),
-            paymentIntent = paymentIntent?.toApi(),
-            apiError = apiError?.toString(),
-        )
+        code = code,
+        message = errorMessage,
+        stackTrace = stackTraceToString(),
+        paymentIntent = paymentIntent?.toApi(),
+        apiError = apiError?.toString(),
+    )
 }
 
 private fun TerminalErrorCode.toApiCode(): TerminalExceptionCodeApi? {
@@ -312,7 +312,11 @@ fun PaymentIntent.toApi(): PaymentIntentApi {
         created = created,
         status = status!!.toApi(),
         amount = amount.toDouble(),
-        captureMethod = captureMethod!!,
+        captureMethod = when (captureMethod!!) {
+            "automatic" -> CaptureMethodApi.AUTOMATIC
+            "manual" -> CaptureMethodApi.MANUAL
+            else -> throw IllegalArgumentException("Not supported CaptureMethod '${captureMethod}' on PaymentIntent $id")
+        },
         currency = currency!!,
         metadata = metadata?.toHashMap() ?: hashMapOf(),
         paymentMethodId = paymentMethodId,
@@ -322,20 +326,28 @@ fun PaymentIntent.toApi(): PaymentIntentApi {
         // Only Android
         amountCapturable = amountCapturable.toDouble(),
         amountReceived = amountReceived.toDouble(),
-        application = application,
+        applicationId = application,
         applicationFeeAmount = applicationFeeAmount.toDouble(),
         canceledAt = canceledAt,
         cancellationReason = cancellationReason,
         clientSecret = clientSecret,
-        confirmationMethod = confirmationMethod,
+        confirmationMethod = when (confirmationMethod) {
+            "automatic" -> ConfirmationMethodApi.AUTOMATIC
+            "manual" -> ConfirmationMethodApi.MANUAL
+            else -> null
+        },
         description = description,
-        invoice = invoice,
+        invoiceId = invoice,
         onBehalfOf = onBehalfOf,
         receiptEmail = receiptEmail,
-        review = review,
-        setupFutureUsage = setupFutureUsage,
+        reviewId = review,
+        setupFutureUsage = when (setupFutureUsage) {
+            "on_session" -> PaymentIntentUsageApi.ON_SESSION
+            "off_session" -> PaymentIntentUsageApi.OFF_SESSION
+            else -> null
+        },
         transferGroup = transferGroup,
-        customer = customer,
+        customerId = customer,
     )
 }
 
@@ -416,7 +428,7 @@ fun SetupAttempt.toApi(): SetupAttemptApi {
         applicationId = applicationId,
         created = created,
         customerId = customerId,
-        onBehalfOfId = onBehalfOfId,
+        onBehalfOf = onBehalfOfId,
         paymentMethodId = paymentMethodId,
         paymentMethodDetails = paymentMethodDetails.toApi(),
         setupIntentId = setupIntentId!!,

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/ToHostExtensions.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/ToHostExtensions.kt
@@ -64,6 +64,13 @@ fun CartLineItemApi.toHost(): CartLineItem {
     ).build()
 }
 
+fun PaymentIntentUsageApi.toHost(): String {
+    return when (this) {
+        PaymentIntentUsageApi.OFF_SESSION -> "off_session"
+        PaymentIntentUsageApi.ON_SESSION -> "on_session"
+    }
+}
+
 fun PaymentIntentParametersApi.toHost(): PaymentIntentParameters {
     val b = PaymentIntentParameters.Builder(
         amount = amount,
@@ -90,7 +97,7 @@ fun PaymentIntentParametersApi.toHost(): PaymentIntentParameters {
     transferDataDestination?.let(b::setTransferDataDestination)
     transferGroup?.let(b::setTransferGroup)
     onBehalfOf?.let(b::setOnBehalfOf)
-    setupFutureUsage?.let(b::setSetupFutureUsage)
+    setupFutureUsage?.toHost()?.let(b::setSetupFutureUsage)
     paymentMethodOptionsParameters?.let { b.setPaymentMethodOptionsParameters(it.toHost()) }
     return b.build()
 }

--- a/stripe_terminal/ios/Classes/Api/TerminalApi.swift
+++ b/stripe_terminal/ios/Classes/Api/TerminalApi.swift
@@ -717,6 +717,11 @@ struct CartLineItemApi {
     }
 }
 
+enum ConfirmationMethodApi: Int {
+    case automatic
+    case manual
+}
+
 enum ConnectionStatusApi: Int {
     case notConnected
     case connected
@@ -872,7 +877,7 @@ struct PaymentIntentApi {
     let created: Date
     let status: PaymentIntentStatusApi
     let amount: Double
-    let captureMethod: String
+    let captureMethod: CaptureMethodApi
     let currency: String
     let metadata: [String: String]
     let paymentMethodId: String?
@@ -881,19 +886,19 @@ struct PaymentIntentApi {
     let statementDescriptorSuffix: String?
     let amountCapturable: Double?
     let amountReceived: Double?
-    let application: String?
+    let applicationId: String?
     let applicationFeeAmount: Double?
     let cancellationReason: String?
     let canceledAt: Date?
     let clientSecret: String?
-    let confirmationMethod: String?
-    let customer: String?
+    let confirmationMethod: ConfirmationMethodApi?
+    let customerId: String?
     let description: String?
-    let invoice: String?
+    let invoiceId: String?
     let onBehalfOf: String?
-    let review: String?
+    let reviewId: String?
     let receiptEmail: String?
-    let setupFutureUsage: String?
+    let setupFutureUsage: PaymentIntentUsageApi?
     let transferGroup: String?
 
     func serialize() -> [Any?] {
@@ -902,7 +907,7 @@ struct PaymentIntentApi {
             Int(created.timeIntervalSince1970 * 1000),
             status.rawValue,
             amount,
-            captureMethod,
+            captureMethod.rawValue,
             currency,
             metadata != nil ? Dictionary(uniqueKeysWithValues: metadata.map { k, v in (k, v) }) : nil,
             paymentMethodId,
@@ -911,19 +916,19 @@ struct PaymentIntentApi {
             statementDescriptorSuffix,
             amountCapturable,
             amountReceived,
-            application,
+            applicationId,
             applicationFeeAmount,
             cancellationReason,
             canceledAt != nil ? Int(canceledAt!.timeIntervalSince1970 * 1000) : nil,
             clientSecret,
-            confirmationMethod,
-            customer,
+            confirmationMethod?.rawValue,
+            customerId,
             description,
-            invoice,
+            invoiceId,
             onBehalfOf,
-            review,
+            reviewId,
             receiptEmail,
-            setupFutureUsage,
+            setupFutureUsage?.rawValue,
             transferGroup,
         ]
     }
@@ -944,7 +949,7 @@ struct PaymentIntentParametersApi {
     let transferDataDestination: String?
     let transferGroup: String?
     let onBehalfOf: String?
-    let setupFutureUsage: String?
+    let setupFutureUsage: PaymentIntentUsageApi?
     let paymentMethodOptionsParameters: PaymentMethodOptionsParametersApi?
 
     static func deserialize(
@@ -965,7 +970,7 @@ struct PaymentIntentParametersApi {
             transferDataDestination: serialized[11] as? String,
             transferGroup: serialized[12] as? String,
             onBehalfOf: serialized[13] as? String,
-            setupFutureUsage: serialized[14] as? String,
+            setupFutureUsage: !(serialized[14] is NSNull) ? PaymentIntentUsageApi(rawValue: serialized[14] as! Int)! : nil,
             paymentMethodOptionsParameters: !(serialized[15] is NSNull) ? PaymentMethodOptionsParametersApi.deserialize(serialized[15] as! [Any?]) : nil
         )
     }
@@ -977,7 +982,13 @@ enum PaymentIntentStatusApi: Int {
     case requiresCapture
     case requiresConfirmation
     case requiresPaymentMethod
+    case requiresAction
     case succeeded
+}
+
+enum PaymentIntentUsageApi: Int {
+    case onSession
+    case offSession
 }
 
 struct PaymentMethodDetailsApi {
@@ -1153,7 +1164,7 @@ struct SetupAttemptApi {
     let applicationId: String?
     let created: Date
     let customerId: String?
-    let onBehalfOfId: String?
+    let onBehalfOf: String?
     let paymentMethodId: String?
     let paymentMethodDetails: SetupAttemptPaymentMethodDetailsApi?
     let setupIntentId: String
@@ -1165,7 +1176,7 @@ struct SetupAttemptApi {
             applicationId,
             Int(created.timeIntervalSince1970 * 1000),
             customerId,
-            onBehalfOfId,
+            onBehalfOf,
             paymentMethodId,
             paymentMethodDetails?.serialize(),
             setupIntentId,

--- a/stripe_terminal/ios/Classes/Api/ToApiExtensions.swift
+++ b/stripe_terminal/ios/Classes/Api/ToApiExtensions.swift
@@ -44,8 +44,10 @@ extension PaymentIntentStatus {
             return .canceled
         case .succeeded:
             return .succeeded
+        case .requiresAction:
+            return .requiresAction
         @unknown default:
-            fatalError("WTF")
+            fatalError("Not supported payment intent status: \(self)")
         }
     }
 }
@@ -374,17 +376,17 @@ extension PaymentIntent {
             // Only Android
             amountCapturable: nil,
             amountReceived: nil,
-            application: nil,
+            applicationId: nil,
             applicationFeeAmount: nil,
             cancellationReason: nil,
             canceledAt: nil,
             clientSecret: nil,
             confirmationMethod: nil,
-            customer: nil,
+            customerId: nil,
             description: description,
-            invoice: nil,
+            invoiceId: nil,
             onBehalfOf: nil,
-            review: nil,
+            reviewId: nil,
             receiptEmail: nil,
             setupFutureUsage: nil,
             transferGroup: nil
@@ -393,14 +395,14 @@ extension PaymentIntent {
 }
 
 extension CaptureMethod {
-    func toApi() -> String {
+    func toApi() -> CaptureMethodApi {
         switch self {
         case .manual:
-            return "manual"
+            return CaptureMethodApi.manual
         case .automatic:
-            return "automatic"
+            return CaptureMethodApi.automatic
         @unknown default:
-            fatalError("WTF")
+            fatalError("Not supported CaptureMethodApi '\(self)'")
         }
     }
 }
@@ -477,7 +479,7 @@ extension SetupAttempt {
             applicationId: application,
             created: created,
             customerId: customer,
-            onBehalfOfId: onBehalfOf,
+            onBehalfOf: onBehalfOf,
             paymentMethodId: paymentMethod,
             paymentMethodDetails: paymentMethodDetails?.toApi(),
             setupIntentId: setupIntent,

--- a/stripe_terminal/ios/Classes/Api/ToHostExtensions.swift
+++ b/stripe_terminal/ios/Classes/Api/ToHostExtensions.swift
@@ -19,7 +19,7 @@ extension PaymentIntentParametersApi {
             .setTransferDataDestination(transferDataDestination)
             .setTransferGroup(transferGroup)
             .setOnBehalfOf(onBehalfOf)
-            .setSetupFutureUsage(setupFutureUsage)
+            .setSetupFutureUsage(setupFutureUsage?.toHost())
         if let it = paymentMethodOptionsParameters { b.setPaymentMethodOptionsParameters(try it.toHost()) }
         return try b.build()
     }
@@ -85,6 +85,17 @@ extension CaptureMethodApi {
             return .automatic
         case .manual:
             return .manual
+        }
+    }
+}
+
+extension PaymentIntentUsageApi {
+    func toHost() -> String {
+        switch self {
+        case .offSession:
+            return "off_session"
+        case .onSession:
+            return "on_session"
         }
     }
 }

--- a/stripe_terminal/lib/src/models/payment_intent.dart
+++ b/stripe_terminal/lib/src/models/payment_intent.dart
@@ -13,10 +13,10 @@ part 'payment_intent.g.dart';
 @DataClass()
 class PaymentIntent with _$PaymentIntent {
   /// The unique identifier for the intent.
-  //
-  // If the intent was created offline the [id] will be nil. See offlineDetails.stripeId for a unique ID to use while offline.
-  //
-  // After the payment has been forwarded the intent’s [id] will be filled in.
+  ///
+  /// If the intent was created offline the [id] will be nil. See offlineDetails.stripeId for a
+  /// unique ID to use while offline.
+  /// After the payment has been forwarded the intent’s [id] will be filled in.
   final String id;
 
   /// When the intent was created.
@@ -29,7 +29,7 @@ class PaymentIntent with _$PaymentIntent {
   final double amount;
 
   /// Controls when the funds will be captured from the customer’s account.
-  final String captureMethod;
+  final CaptureMethod captureMethod;
 
   /// The currency of the payment.
   final String currency;
@@ -55,7 +55,7 @@ class PaymentIntent with _$PaymentIntent {
   /// [statementDescriptor] on your customer’s statement when this [PaymentIntent] succeeds in creating a charge.
   final String? statementDescriptorSuffix;
 
-  /// !!! ONLY ON ANDROID !!!
+  // !!! ONLY ON ANDROID !!!
 
   /// Amount that can be captured from this [PaymentIntent].
   final double? amountCapturable;
@@ -64,8 +64,7 @@ class PaymentIntent with _$PaymentIntent {
   final double? amountReceived;
 
   /// ID of the Connect application that created the [PaymentIntent].
-  // TODO: rename to applicationId
-  final String? application;
+  final String? applicationId;
 
   /// The amount of the application fee for this [PaymentIntent].
   final double? applicationFeeAmount;
@@ -85,34 +84,30 @@ class PaymentIntent with _$PaymentIntent {
   /// One of automatic (default) or manual. When the confirmation method is automatic, a [PaymentIntent]
   /// can be confirmed using a publishable key. After next_actions are handled, no additional confirmation
   /// is required to complete the payment.
-  // TODO: Convert to [CaptureMethod] type
-  final String? confirmationMethod;
+  final ConfirmationMethod? confirmationMethod;
 
   /// ID of the Customer this PaymentIntent belongs to, if one exists. If present, payment methods
   /// used with this [PaymentIntent] can only be attached to this Customer, and payment methods
   /// attached to other Customers cannot be used with this [PaymentIntent].
-  // TODO: rename to customerId
-  final String? customer;
+  final String? customerId;
 
   /// An arbitrary string attached to the [PaymentIntent]. Often useful for displaying to users.
   final String? description;
 
   /// ID of the invoice that created this PaymentIntent, if it exists.
-  // TODO: rename to invoiceId
-  final String? invoice;
+  final String? invoiceId;
 
   /// Return the account that the PaymentIntent is on behalf of
   final String? onBehalfOf;
 
   /// ID of the review associated with this PaymentIntent, if any.
-  // TODO: rename to reviewId
-  final String? review;
+  final String? reviewId;
 
   /// Email address that the receipt for the resulting payment will be sent to.
   final String? receiptEmail;
 
   /// Value of setup_future_usage associated with this [PaymentIntent], if any.
-  final String? setupFutureUsage;
+  final PaymentIntentUsage? setupFutureUsage;
 
   /// Get the transfer group of this PaymentIntent
   final String? transferGroup;
@@ -130,19 +125,19 @@ class PaymentIntent with _$PaymentIntent {
     required this.statementDescriptor,
     required this.statementDescriptorSuffix,
     this.metadata = const {},
-    required this.application,
+    required this.applicationId,
     required this.captureMethod,
     required this.cancellationReason,
     required this.canceledAt,
     required this.clientSecret,
     required this.confirmationMethod,
     required this.currency,
-    required this.customer,
+    required this.customerId,
     required this.description,
-    required this.invoice,
+    required this.invoiceId,
     required this.onBehalfOf,
     required this.paymentMethodId,
-    required this.review,
+    required this.reviewId,
     required this.receiptEmail,
     required this.setupFutureUsage,
     required this.transferGroup,
@@ -150,6 +145,8 @@ class PaymentIntent with _$PaymentIntent {
 }
 
 /// The possible statuses for a [PaymentIntent].
+///
+/// https://stripe.com/docs/api/payment_intents/object#payment_intent_object-status
 enum PaymentIntentStatus {
   /// The [PaymentIntent] was canceled.
   canceled,
@@ -166,10 +163,13 @@ enum PaymentIntentStatus {
   /// Next step: collect a payment method by calling [Terminal.collectPaymentMethod].
   requiresPaymentMethod,
 
+  /// Next step: the payment requires additional actions, such as authenticating with 3D Secure.
+  ///
+  /// PaymentIntents collected with the Terminal SDK should not end in the requires_action status.
+  requiresAction,
+
   /// The [PaymentIntent] succeeded.
   succeeded,
-
-  // TODO: Missing `requiredAction` value
 }
 
 @DataClass()
@@ -243,12 +243,7 @@ class PaymentIntentParameters with _$PaymentIntentParameters {
   /// after the [PaymentIntent] is confirmed and any required actions from the user are complete.
   /// If no Customer was provided, the payment method can still be attached to a Customer after
   /// the transaction completes.
-  ///
-  /// Possible values: “on_session”: Use “on_session” if you intend to only reuse the payment method
-  /// when your customer is present in your checkout flow. “off_session”: Use “off_session” if your
-  /// customer may or may not be present in your checkout flow.
-  // TODO: Convert to [SetupIntentUsage] type
-  final String? setupFutureUsage;
+  final PaymentIntentUsage? setupFutureUsage;
 
   /// Specific options used during the creation of the PaymentMethod.
   final PaymentMethodOptionsParameters? paymentMethodOptionsParameters;
@@ -294,6 +289,25 @@ enum CaptureMethod {
   /// the funds until later. Will require an explicit call to capture payments.
   /// (Not all payment methods support this.)
   manual
+}
+
+enum ConfirmationMethod {
+  /// After next_actions are handled, no additional confirmation is required to complete the payment.
+  automatic,
+
+  /// All payment attempts must be made using a secret key. The PaymentIntent returns to the
+  /// requires_confirmation state after handling next_actions, and requires your server to
+  /// initiate each payment attempt with an explicit confirmation.
+  manual,
+}
+
+enum PaymentIntentUsage {
+  /// Use “on_session” if you intend to only reuse the payment method when your customer
+  /// is present in your checkout flow.
+  onSession,
+
+  /// Use “off_session” if your customer may or may not be present in your checkout flow.
+  offSession
 }
 
 /// The PaymentMethodOptionsParameters contains options for PaymentMethod creation.

--- a/stripe_terminal/lib/src/models/payment_intent.g.dart
+++ b/stripe_terminal/lib/src/models/payment_intent.g.dart
@@ -26,17 +26,17 @@ mixin _$PaymentIntent {
           _self.statementDescriptorSuffix == other.statementDescriptorSuffix &&
           _self.amountCapturable == other.amountCapturable &&
           _self.amountReceived == other.amountReceived &&
-          _self.application == other.application &&
+          _self.applicationId == other.applicationId &&
           _self.applicationFeeAmount == other.applicationFeeAmount &&
           _self.cancellationReason == other.cancellationReason &&
           _self.canceledAt == other.canceledAt &&
           _self.clientSecret == other.clientSecret &&
           _self.confirmationMethod == other.confirmationMethod &&
-          _self.customer == other.customer &&
+          _self.customerId == other.customerId &&
           _self.description == other.description &&
-          _self.invoice == other.invoice &&
+          _self.invoiceId == other.invoiceId &&
           _self.onBehalfOf == other.onBehalfOf &&
-          _self.review == other.review &&
+          _self.reviewId == other.reviewId &&
           _self.receiptEmail == other.receiptEmail &&
           _self.setupFutureUsage == other.setupFutureUsage &&
           _self.transferGroup == other.transferGroup;
@@ -56,17 +56,17 @@ mixin _$PaymentIntent {
     hashCode = $hashCombine(hashCode, _self.statementDescriptorSuffix.hashCode);
     hashCode = $hashCombine(hashCode, _self.amountCapturable.hashCode);
     hashCode = $hashCombine(hashCode, _self.amountReceived.hashCode);
-    hashCode = $hashCombine(hashCode, _self.application.hashCode);
+    hashCode = $hashCombine(hashCode, _self.applicationId.hashCode);
     hashCode = $hashCombine(hashCode, _self.applicationFeeAmount.hashCode);
     hashCode = $hashCombine(hashCode, _self.cancellationReason.hashCode);
     hashCode = $hashCombine(hashCode, _self.canceledAt.hashCode);
     hashCode = $hashCombine(hashCode, _self.clientSecret.hashCode);
     hashCode = $hashCombine(hashCode, _self.confirmationMethod.hashCode);
-    hashCode = $hashCombine(hashCode, _self.customer.hashCode);
+    hashCode = $hashCombine(hashCode, _self.customerId.hashCode);
     hashCode = $hashCombine(hashCode, _self.description.hashCode);
-    hashCode = $hashCombine(hashCode, _self.invoice.hashCode);
+    hashCode = $hashCombine(hashCode, _self.invoiceId.hashCode);
     hashCode = $hashCombine(hashCode, _self.onBehalfOf.hashCode);
-    hashCode = $hashCombine(hashCode, _self.review.hashCode);
+    hashCode = $hashCombine(hashCode, _self.reviewId.hashCode);
     hashCode = $hashCombine(hashCode, _self.receiptEmail.hashCode);
     hashCode = $hashCombine(hashCode, _self.setupFutureUsage.hashCode);
     hashCode = $hashCombine(hashCode, _self.transferGroup.hashCode);
@@ -88,17 +88,17 @@ mixin _$PaymentIntent {
         ..add('statementDescriptorSuffix', _self.statementDescriptorSuffix)
         ..add('amountCapturable', _self.amountCapturable)
         ..add('amountReceived', _self.amountReceived)
-        ..add('application', _self.application)
+        ..add('application', _self.applicationId)
         ..add('applicationFeeAmount', _self.applicationFeeAmount)
         ..add('cancellationReason', _self.cancellationReason)
         ..add('canceledAt', _self.canceledAt)
         ..add('clientSecret', _self.clientSecret)
         ..add('confirmationMethod', _self.confirmationMethod)
-        ..add('customer', _self.customer)
+        ..add('customer', _self.customerId)
         ..add('description', _self.description)
-        ..add('invoice', _self.invoice)
+        ..add('invoice', _self.invoiceId)
         ..add('onBehalfOf', _self.onBehalfOf)
-        ..add('review', _self.review)
+        ..add('review', _self.reviewId)
         ..add('receiptEmail', _self.receiptEmail)
         ..add('setupFutureUsage', _self.setupFutureUsage)
         ..add('transferGroup', _self.transferGroup))

--- a/stripe_terminal/lib/src/models/setup_intent.dart
+++ b/stripe_terminal/lib/src/models/setup_intent.dart
@@ -42,7 +42,7 @@ class SetupIntent with _$SetupIntent {
   });
 }
 
-/// The SetupIntent usage options tell Stripe how the payment method is intended to be used in the future.
+/// The [SetupIntent] usage options tell Stripe how the payment method is intended to be used in the future.
 /// Stripe will use the chosen option to pick the most frictionless flow for the customer.
 enum SetupIntentUsage {
   /// An on-session usage indicates to Stripe that future payments will take place while the customer
@@ -52,7 +52,7 @@ enum SetupIntentUsage {
   onSession,
 
   /// An off-session usage indicates to Stripe that future payments will take place without
-  /// the direct involvement of the customer. Creating an off-session SetupIntent might incur some
+  /// the direct involvement of the customer. Creating an off-session [SetupIntent] might incur some
   /// initial friction from additional authentication steps, but can reduce customer intervention
   /// in later off-session payments.
   offSession
@@ -85,8 +85,7 @@ class SetupAttempt with _$SetupAttempt {
   final String? customerId;
 
   /// (Connect) The account (if any) for which the setup is intended.
-  // TODO: Rename to onBehalfOf
-  final String? onBehalfOfId;
+  final String? onBehalfOf;
 
   /// ID of the payment method used with this SetupAttempt.
   final String? paymentMethodId;
@@ -106,7 +105,7 @@ class SetupAttempt with _$SetupAttempt {
     required this.applicationId,
     required this.created,
     required this.customerId,
-    required this.onBehalfOfId,
+    required this.onBehalfOf,
     required this.paymentMethodId,
     required this.paymentMethodDetails,
     required this.setupIntentId,

--- a/stripe_terminal/lib/src/models/setup_intent.g.dart
+++ b/stripe_terminal/lib/src/models/setup_intent.g.dart
@@ -56,7 +56,7 @@ mixin _$SetupAttempt {
           _self.applicationId == other.applicationId &&
           _self.created == other.created &&
           _self.customerId == other.customerId &&
-          _self.onBehalfOfId == other.onBehalfOfId &&
+          _self.onBehalfOf == other.onBehalfOf &&
           _self.paymentMethodId == other.paymentMethodId &&
           _self.paymentMethodDetails == other.paymentMethodDetails &&
           _self.setupIntentId == other.setupIntentId &&
@@ -68,7 +68,7 @@ mixin _$SetupAttempt {
     hashCode = $hashCombine(hashCode, _self.applicationId.hashCode);
     hashCode = $hashCombine(hashCode, _self.created.hashCode);
     hashCode = $hashCombine(hashCode, _self.customerId.hashCode);
-    hashCode = $hashCombine(hashCode, _self.onBehalfOfId.hashCode);
+    hashCode = $hashCombine(hashCode, _self.onBehalfOf.hashCode);
     hashCode = $hashCombine(hashCode, _self.paymentMethodId.hashCode);
     hashCode = $hashCombine(hashCode, _self.paymentMethodDetails.hashCode);
     hashCode = $hashCombine(hashCode, _self.setupIntentId.hashCode);
@@ -82,7 +82,7 @@ mixin _$SetupAttempt {
         ..add('applicationId', _self.applicationId)
         ..add('created', _self.created)
         ..add('customerId', _self.customerId)
-        ..add('onBehalfOfId', _self.onBehalfOfId)
+        ..add('onBehalfOfId', _self.onBehalfOf)
         ..add('paymentMethodId', _self.paymentMethodId)
         ..add('paymentMethodDetails', _self.paymentMethodDetails)
         ..add('setupIntentId', _self.setupIntentId)

--- a/stripe_terminal/lib/src/platform/terminal_platform.api.dart
+++ b/stripe_terminal/lib/src/platform/terminal_platform.api.dart
@@ -525,7 +525,7 @@ PaymentIntent _$deserializePaymentIntent(List<Object?> serialized) => PaymentInt
     created: DateTime.fromMillisecondsSinceEpoch(serialized[1] as int),
     status: PaymentIntentStatus.values[serialized[2] as int],
     amount: serialized[3] as double,
-    captureMethod: serialized[4] as String,
+    captureMethod: CaptureMethod.values[serialized[4] as int],
     currency: serialized[5] as String,
     metadata: (serialized[6] as Map).map((k, v) => MapEntry(k as String, v as String)),
     paymentMethodId: serialized[7] as String?,
@@ -534,20 +534,22 @@ PaymentIntent _$deserializePaymentIntent(List<Object?> serialized) => PaymentInt
     statementDescriptorSuffix: serialized[10] as String?,
     amountCapturable: serialized[11] as double?,
     amountReceived: serialized[12] as double?,
-    application: serialized[13] as String?,
+    applicationId: serialized[13] as String?,
     applicationFeeAmount: serialized[14] as double?,
     cancellationReason: serialized[15] as String?,
     canceledAt:
         serialized[16] != null ? DateTime.fromMillisecondsSinceEpoch(serialized[16] as int) : null,
     clientSecret: serialized[17] as String?,
-    confirmationMethod: serialized[18] as String?,
-    customer: serialized[19] as String?,
+    confirmationMethod:
+        serialized[18] != null ? ConfirmationMethod.values[serialized[18] as int] : null,
+    customerId: serialized[19] as String?,
     description: serialized[20] as String?,
-    invoice: serialized[21] as String?,
+    invoiceId: serialized[21] as String?,
     onBehalfOf: serialized[22] as String?,
-    review: serialized[23] as String?,
+    reviewId: serialized[23] as String?,
     receiptEmail: serialized[24] as String?,
-    setupFutureUsage: serialized[25] as String?,
+    setupFutureUsage:
+        serialized[25] != null ? PaymentIntentUsage.values[serialized[25] as int] : null,
     transferGroup: serialized[26] as String?);
 List<Object?> _$serializePaymentIntentParameters(PaymentIntentParameters deserialized) => [
       deserialized.amount,
@@ -564,7 +566,7 @@ List<Object?> _$serializePaymentIntentParameters(PaymentIntentParameters deseria
       deserialized.transferDataDestination,
       deserialized.transferGroup,
       deserialized.onBehalfOf,
-      deserialized.setupFutureUsage,
+      deserialized.setupFutureUsage?.index,
       deserialized.paymentMethodOptionsParameters != null
           ? _$serializePaymentMethodOptionsParameters(deserialized.paymentMethodOptionsParameters!)
           : null
@@ -623,7 +625,7 @@ SetupAttempt _$deserializeSetupAttempt(List<Object?> serialized) => SetupAttempt
     applicationId: serialized[1] as String?,
     created: DateTime.fromMillisecondsSinceEpoch(serialized[2] as int),
     customerId: serialized[3] as String?,
-    onBehalfOfId: serialized[4] as String?,
+    onBehalfOf: serialized[4] as String?,
     paymentMethodId: serialized[5] as String?,
     paymentMethodDetails: serialized[6] != null
         ? _$deserializeSetupAttemptPaymentMethodDetails(serialized[6] as List)


### PR DESCRIPTION
refactor: Now `PaymentIntent.captureMethod` is a Enum `CaptureMethod`
refactor: Now `PaymentIntent.confirmationMethod` is a Enum `ConfirmationMethod`
refactor: Now `PaymentIntent.setupFutureUsage` is a Enum `PaymentIntentUsage`
refactor: Renamed on `PaymentIntent`: `application` to `applicationId`, `customer` to `customerId`, `invoice` to `invoiceId`, `review` to `reviewId`
fix: Added support on `PaymentIntentStatus` to `requiresAction` value
refactor: Now `PaymentIntentParameters.setupFutureUsage` is a Enum `PaymentIntentUsage`
refactor: Renamed on `SetupAttempt`: `onBehalfOfId` to `onBehalfOf`