### PR TITLE
fix(android): Fixes TapToPay error "Must have a country code to connect to reader"

### DIFF
--- a/stripe_terminal/CHANGELOG.md
+++ b/stripe_terminal/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+
+## 3.0.1
+- fix(android): Fixes TapToPay error "Must have a country code to connect to reader" [#29](https://github.com/BreX900/mek-packages/issues/29)
+
 ## 3.0.0
 - fix: Attached the delegate reader before trying the connection
 - refactor: Renamed `StripeTerminal` class to `Terminal`. The name has been aligned with the native SDKs.

--- a/stripe_terminal/android/build.gradle
+++ b/stripe_terminal/android/build.gradle
@@ -66,6 +66,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    api "com.stripe:stripeterminal-localmobile:3.0.0"
-    api "com.stripe:stripeterminal-core:3.0.0"
+    api "com.stripe:stripeterminal-localmobile:3.1.0"
+    api "com.stripe:stripeterminal-core:3.1.0"
 }

--- a/stripe_terminal/example/pubspec.lock
+++ b/stripe_terminal/example/pubspec.lock
@@ -140,7 +140,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.0-dev.1"
+    version: "3.0.1"
   meta:
     dependency: transitive
     description:

--- a/stripe_terminal/pubspec.yaml
+++ b/stripe_terminal/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mek_stripe_terminal
 description: A StripeTerminal plugin to discover readers, connect to them and process payments.
-version: 3.0.0
+version: 3.0.1
 repository: https://github.com/BreX900/mek-packages/tree/main/stripe_terminal
 topics:
   - stripe-terminal


### PR DESCRIPTION
fix [#29](https://github.com/BreX900/mek-packages/issues/29)