### PR TITLE
Resolve tap to pay connected account issue on iOS

### DIFF
--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/TerminalPlugin.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/TerminalPlugin.kt
@@ -202,7 +202,8 @@ class TerminalPlugin : FlutterPlugin, ActivityAware, TerminalPlatformApi {
         result: Result<ReaderApi>,
         serialNumber: String,
         locationId: String,
-        autoReconnectOnUnexpectedDisconnect: Boolean
+        autoReconnectOnUnexpectedDisconnect: Boolean,
+        onBehalfOf: String?,
     ) {
         val reader = findActiveReader(serialNumber)
 

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/TerminalApi.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/TerminalApi.kt
@@ -90,6 +90,7 @@ interface TerminalPlatformApi {
         serialNumber: String,
         locationId: String,
         autoReconnectOnUnexpectedDisconnect: Boolean,
+        onBehalfOf: String?,
     )
 
     fun onConnectUsbReader(
@@ -277,7 +278,7 @@ interface TerminalPlatformApi {
                 }
                 "connectMobileReader" -> {
                     val res = Result<ReaderApi>(result) { it.serialize() }
-                    onConnectMobileReader(res, args[0] as String, args[1] as String, args[2] as Boolean)
+                    onConnectMobileReader(res, args[0] as String, args[1] as String, args[2] as Boolean, args[3] as String?)
                 }
                 "connectUsbReader" -> {
                     val res = Result<ReaderApi>(result) { it.serialize() }
@@ -858,6 +859,7 @@ data class InternetDiscoveryConfigurationApi(
 
 data class LocalMobileDiscoveryConfigurationApi(
     val isSimulated: Boolean,
+    val onBehalfOf: String?,
 ): DiscoveryConfigurationApi() {
     companion object {
         fun deserialize(
@@ -865,6 +867,7 @@ data class LocalMobileDiscoveryConfigurationApi(
         ): LocalMobileDiscoveryConfigurationApi {
             return LocalMobileDiscoveryConfigurationApi(
                 isSimulated = serialized[0] as Boolean,
+                onBehalfOf = serialized[1] as String?,
             )
         }
     }

--- a/stripe_terminal/example/pubspec.lock
+++ b/stripe_terminal/example/pubspec.lock
@@ -114,10 +114,10 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   mek_data_class:
     dependency: transitive
     description:
@@ -145,10 +145,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   one_for_all:
     dependency: "direct overridden"
     description:
@@ -306,14 +306,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.0"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
+  dart: ">=3.2.0-0 <4.0.0"
   flutter: ">=3.10.0"

--- a/stripe_terminal/ios/Classes/Api/TerminalApi.swift
+++ b/stripe_terminal/ios/Classes/Api/TerminalApi.swift
@@ -122,7 +122,8 @@ protocol TerminalPlatformApi {
     func onConnectMobileReader(
         _ serialNumber: String,
         _ locationId: String,
-        _ autoReconnectOnUnexpectedDisconnect: Bool
+        _ autoReconnectOnUnexpectedDisconnect: Bool,
+        _ onBehalfOf: String?
     ) async throws -> ReaderApi
 
     func onConnectUsbReader(
@@ -324,7 +325,7 @@ func setTerminalPlatformApiHandler(
                 }
             case "connectMobileReader":
                 runAsync {
-                    let res = try await hostApi.onConnectMobileReader(args[0] as! String, args[1] as! String, args[2] as! Bool)
+                    let res = try await hostApi.onConnectMobileReader(args[0] as! String, args[1] as! String, args[2] as! Bool, args[3] as? String)
                     return res.serialize()
                 }
             case "connectUsbReader":
@@ -919,12 +920,14 @@ struct InternetDiscoveryConfigurationApi: DiscoveryConfigurationApi {
 
 struct LocalMobileDiscoveryConfigurationApi: DiscoveryConfigurationApi {
     let isSimulated: Bool
+    let onBehalfOf: String?
 
     static func deserialize(
         _ serialized: [Any?]
     ) -> LocalMobileDiscoveryConfigurationApi {
         return LocalMobileDiscoveryConfigurationApi(
-            isSimulated: serialized[0] as! Bool
+            isSimulated: serialized[0] as! Bool,
+            onBehalfOf: serialized[1] as? String
         )
     }
 }

--- a/stripe_terminal/ios/Classes/TerminalPlugin.swift
+++ b/stripe_terminal/ios/Classes/TerminalPlugin.swift
@@ -135,9 +135,11 @@ public class TerminalPlugin: NSObject, FlutterPlugin, TerminalPlatformApi {
     func onConnectMobileReader(
         _ serialNumber: String,
         _ locationId: String,
-        _ autoReconnectOnUnexpectedDisconnect: Bool
+        _ autoReconnectOnUnexpectedDisconnect: Bool,
+        _ onBehalfOf: String?
     ) async throws -> ReaderApi {
         let config = LocalMobileConnectionConfigurationBuilder(locationId: locationId)
+            .setOnBehalfOf(onBehalfOf)
             .setAutoReconnectOnUnexpectedDisconnect(autoReconnectOnUnexpectedDisconnect)
             .setAutoReconnectionDelegate(_readerReconnectionDelegate)
         do {

--- a/stripe_terminal/lib/src/models/discovery_configuration.dart
+++ b/stripe_terminal/lib/src/models/discovery_configuration.dart
@@ -90,9 +90,11 @@ class InternetDiscoveryConfiguration extends DiscoveryConfiguration {
 /// or one running an unsupported version of iOS.
 class LocalMobileDiscoveryConfiguration extends DiscoveryConfiguration {
   final bool isSimulated;
+  final String? onBehalfOf;
 
   const LocalMobileDiscoveryConfiguration({
     this.isSimulated = false,
+    this.onBehalfOf,
   });
 }
 

--- a/stripe_terminal/lib/src/platform/terminal_platform.api.dart
+++ b/stripe_terminal/lib/src/platform/terminal_platform.api.dart
@@ -116,10 +116,11 @@ class _$TerminalPlatform implements TerminalPlatform {
     String serialNumber, {
     required String locationId,
     required bool autoReconnectOnUnexpectedDisconnect,
+    String? onBehalfOf,
   }) async {
     try {
-      final result = await _$channel.invokeMethod(
-          'connectMobileReader', [serialNumber, locationId, autoReconnectOnUnexpectedDisconnect]);
+      final result = await _$channel.invokeMethod('connectMobileReader',
+          [serialNumber, locationId, autoReconnectOnUnexpectedDisconnect, onBehalfOf]);
       return _$deserializeReader(result as List);
     } on PlatformException catch (exception) {
       TerminalPlatform._throwIfIsHostException(exception);
@@ -604,7 +605,7 @@ List<Object?> _$serializeInternetDiscoveryConfiguration(
     ['InternetDiscoveryConfiguration', deserialized.isSimulated, deserialized.locationId];
 List<Object?> _$serializeLocalMobileDiscoveryConfiguration(
         LocalMobileDiscoveryConfiguration deserialized) =>
-    ['LocalMobileDiscoveryConfiguration', deserialized.isSimulated];
+    ['LocalMobileDiscoveryConfiguration', deserialized.isSimulated, deserialized.onBehalfOf];
 List<Object?> _$serializeUsbDiscoveryConfiguration(UsbDiscoveryConfiguration deserialized) =>
     ['UsbDiscoveryConfiguration', deserialized.isSimulated, deserialized.timeout?.inMicroseconds];
 Location _$deserializeLocation(List<Object?> serialized) => Location(

--- a/stripe_terminal/lib/src/platform/terminal_platform.dart
+++ b/stripe_terminal/lib/src/platform/terminal_platform.dart
@@ -69,6 +69,7 @@ abstract class TerminalPlatform {
     String serialNumber, {
     required String locationId,
     required bool autoReconnectOnUnexpectedDisconnect,
+    String? onBehalfOf,
   });
 
   Future<Reader> connectUsbReader(

--- a/stripe_terminal/lib/src/terminal.dart
+++ b/stripe_terminal/lib/src/terminal.dart
@@ -58,7 +58,8 @@ class Terminal {
     }();
   }
 
-  Future<void> clearCachedCredentials() async => await _platform.clearCachedCredentials();
+  Future<void> clearCachedCredentials() async =>
+      await _platform.clearCachedCredentials();
 
 //region Reader discovery, connection and updates
   /// The currently connected reader’s connectionStatus changed.
@@ -67,10 +68,12 @@ class Terminal {
   /// as it cannot be used to accurately distinguish between expected and unexpected disconnect events.
   /// To detect unexpect disconnects (e.g. to automatically notify your user), you should instead use
   /// the [onUnexpectedReaderDisconnect] stream.
-  Stream<ConnectionStatus> get onConnectionStatusChange => _handlers.connectionStatusChangeStream;
+  Stream<ConnectionStatus> get onConnectionStatusChange =>
+      _handlers.connectionStatusChangeStream;
 
   /// Get the current [ConnectionStatus]
-  Future<ConnectionStatus> getConnectionStatus() async => await _platform.getConnectionStatus();
+  Future<ConnectionStatus> getConnectionStatus() async =>
+      await _platform.getConnectionStatus();
 
   /// The reader disconnected unexpectedly (that is, without your app explicitly calling [disconnectReader]).
   ///
@@ -79,7 +82,8 @@ class Terminal {
   /// to automatically reconnect to the disconnected reader, or display UI for your user to re-connect to a reader.
   ///
   /// You can trigger this call in your app by powering off the connected reader.
-  Stream<Reader> get onUnexpectedReaderDisconnect => _handlers.unexpectedReaderDisconnectStream;
+  Stream<Reader> get onUnexpectedReaderDisconnect =>
+      _handlers.unexpectedReaderDisconnectStream;
 
   /// Use this method to determine whether the mobile device supports a given reader type using a
   /// particular discovery method.
@@ -125,7 +129,8 @@ class Terminal {
   /// When connect* method is called, the SDK uses a connection token and the given reader information
   ///   to register the reader to your Stripe account. If the SDK does not already have a connection token,
   ///   it will call the fetchToken method which was passed as an argument in [getInstance].
-  Stream<List<Reader>> discoverReaders(DiscoveryConfiguration discoveryConfiguration) {
+  Stream<List<Reader>> discoverReaders(
+      DiscoveryConfiguration discoveryConfiguration) {
     _controller = _handleStream(_controller, () {
       return _platform.discoverReaders(discoveryConfiguration);
     });
@@ -150,18 +155,22 @@ class Terminal {
     PhysicalReaderDelegate? delegate,
     ReaderReconnectionDelegate? reconnectionDelegate,
   }) async {
-    assert(!autoReconnectOnUnexpectedDisconnect || reconnectionDelegate == null);
-    return await _handleReaderConnection(delegate, reconnectionDelegate, () async {
+    assert(
+        !autoReconnectOnUnexpectedDisconnect || reconnectionDelegate == null);
+    return await _handleReaderConnection(delegate, reconnectionDelegate,
+        () async {
       return await _platform.connectBluetoothReader(
         reader.serialNumber,
         locationId: locationId,
-        autoReconnectOnUnexpectedDisconnect: autoReconnectOnUnexpectedDisconnect,
+        autoReconnectOnUnexpectedDisconnect:
+            autoReconnectOnUnexpectedDisconnect,
       );
     });
   }
 
   /// Attempts to connect to the given Handoff reader with a given connection configuration.
-  Future<Reader> connectHandoffReader(Reader reader, {PhysicalReaderDelegate? delegate}) async {
+  Future<Reader> connectHandoffReader(Reader reader,
+      {PhysicalReaderDelegate? delegate}) async {
     return await _handleReaderConnection(delegate, null, () async {
       return await _platform.connectHandoffReader(reader.serialNumber);
     });
@@ -172,7 +181,8 @@ class Terminal {
     Reader reader, {
     bool failIfInUse = false,
   }) async {
-    return await _platform.connectInternetReader(reader.serialNumber, failIfInUse: failIfInUse);
+    return await _platform.connectInternetReader(reader.serialNumber,
+        failIfInUse: failIfInUse);
   }
 
   /// Attempts to connect to the given Local Mobile reader with a given connection configuration.
@@ -190,15 +200,20 @@ class Terminal {
     Reader reader, {
     required String locationId,
     bool autoReconnectOnUnexpectedDisconnect = false,
+    String? onBehalfOf,
     PhysicalReaderDelegate? delegate,
     ReaderReconnectionDelegate? reconnectionDelegate,
   }) async {
-    assert(!autoReconnectOnUnexpectedDisconnect || reconnectionDelegate == null);
-    return await _handleReaderConnection(delegate, reconnectionDelegate, () async {
+    assert(
+        !autoReconnectOnUnexpectedDisconnect || reconnectionDelegate == null);
+    return await _handleReaderConnection(delegate, reconnectionDelegate,
+        () async {
       return await _platform.connectMobileReader(
         reader.serialNumber,
         locationId: locationId,
-        autoReconnectOnUnexpectedDisconnect: autoReconnectOnUnexpectedDisconnect,
+        autoReconnectOnUnexpectedDisconnect:
+            autoReconnectOnUnexpectedDisconnect,
+        onBehalfOf: onBehalfOf,
       );
     });
   }
@@ -211,18 +226,22 @@ class Terminal {
     ReaderDelegate? delegate,
     ReaderReconnectionDelegate? reconnectionDelegate,
   }) async {
-    assert(!autoReconnectOnUnexpectedDisconnect || reconnectionDelegate == null);
-    return await _handleReaderConnection(delegate, reconnectionDelegate, () async {
+    assert(
+        !autoReconnectOnUnexpectedDisconnect || reconnectionDelegate == null);
+    return await _handleReaderConnection(delegate, reconnectionDelegate,
+        () async {
       return await _platform.connectUsbReader(
         reader.serialNumber,
         locationId: locationId,
-        autoReconnectOnUnexpectedDisconnect: autoReconnectOnUnexpectedDisconnect,
+        autoReconnectOnUnexpectedDisconnect:
+            autoReconnectOnUnexpectedDisconnect,
       );
     });
   }
 
   /// Information about the connected SCPReader, or `null` if no reader is connected.
-  Future<Reader?> getConnectedReader() async => await _platform.getConnectedReader();
+  Future<Reader?> getConnectedReader() async =>
+      await _platform.getConnectedReader();
 
   /// Retrieves a list of [Location] objects belonging to your merchant.
   ///
@@ -262,7 +281,8 @@ class Terminal {
   /// to include this functionality.
   ///
   /// Note: It is an error to call this method when the SDK is connected to the Verifone P400 or WisePOS E readers.
-  Future<void> installAvailableUpdate() async => await _platform.installAvailableUpdate();
+  Future<void> installAvailableUpdate() async =>
+      await _platform.installAvailableUpdate();
 
   /// Reboots the connected reader.
   ///
@@ -274,16 +294,19 @@ class Terminal {
 
   /// The simulator configuration settings that will be used when connecting to and creating payments
   /// with a simulated reader.
-  Future<void> setSimulatorConfiguration(SimulatorConfiguration configuration) async =>
+  Future<void> setSimulatorConfiguration(
+          SimulatorConfiguration configuration) async =>
       await _platform.setSimulatorConfiguration(configuration);
 //endregion
 
 //region Taking payments
   /// The currently connected reader’s [PaymentStatus] changed.
-  Stream<PaymentStatus> get onPaymentStatusChange => _handlers.paymentStatusChangeStream;
+  Stream<PaymentStatus> get onPaymentStatusChange =>
+      _handlers.paymentStatusChangeStream;
 
   /// The Terminal instance’s current payment status.
-  Future<PaymentStatus> getPaymentStatus() async => await _platform.getPaymentStatus();
+  Future<PaymentStatus> getPaymentStatus() async =>
+      await _platform.getPaymentStatus();
 
   /// Creates a new [PaymentIntent] with the given parameters.
   ///
@@ -291,7 +314,8 @@ class Terminal {
   ///   you can create the [PaymentIntent] on your server and use the [retrievePaymentIntent] method
   ///   to retrieve the [PaymentIntent] in your app.
   ///   This cannot be used with the Verifone P400.
-  Future<PaymentIntent> createPaymentIntent(PaymentIntentParameters parameters) async =>
+  Future<PaymentIntent> createPaymentIntent(
+          PaymentIntentParameters parameters) async =>
       await _platform.createPaymentIntent(parameters);
 
   /// Retrieves a [PaymentIntent] with a client secret.
@@ -364,7 +388,8 @@ class Terminal {
   /// If the updated [PaymentIntent]’s status changes to [PaymentIntentStatus.requiresPaymentMethod]
   ///   (e.g., the request failed because the card was declined), call [collectPaymentMethod]
   ///   with the updated [PaymentIntent] to try charging another card.
-  Future<PaymentIntent> confirmPaymentIntent(PaymentIntent paymentIntent) async =>
+  Future<PaymentIntent> confirmPaymentIntent(
+          PaymentIntent paymentIntent) async =>
       await _platform.confirmPaymentIntent(paymentIntent.id);
 
   /// Cancels an [PaymentIntent].
@@ -437,14 +462,17 @@ class Terminal {
     SetupIntent setupIntent, {
     required bool customerConsentCollected,
     bool customerCancellationEnabled = false,
-    @Deprecated('Please use [customerCancellationEnabled]') bool? isCustomerCancellationEnabled,
+    @Deprecated('Please use [customerCancellationEnabled]')
+    bool? isCustomerCancellationEnabled,
   }) {
-    return CancelableFuture(_platform.stopCollectSetupIntentPaymentMethod, (id) async {
+    return CancelableFuture(_platform.stopCollectSetupIntentPaymentMethod,
+        (id) async {
       return await _platform.startCollectSetupIntentPaymentMethod(
         operationId: id,
         setupIntentId: setupIntent.id,
         customerConsentCollected: customerConsentCollected,
-        customerCancellationEnabled: isCustomerCancellationEnabled ?? customerCancellationEnabled,
+        customerCancellationEnabled:
+            isCustomerCancellationEnabled ?? customerCancellationEnabled,
       );
     });
   }
@@ -519,9 +547,11 @@ class Terminal {
     bool? reverseTransfer,
     bool? refundApplicationFee,
     bool customerCancellationEnabled = false,
-    @Deprecated('Please use [customerCancellationEnabled]') bool? isCustomerCancellationEnabled,
+    @Deprecated('Please use [customerCancellationEnabled]')
+    bool? isCustomerCancellationEnabled,
   }) {
-    return CancelableFuture(_platform.stopCollectRefundPaymentMethod, (id) async {
+    return CancelableFuture(_platform.stopCollectRefundPaymentMethod,
+        (id) async {
       return await _platform.startCollectRefundPaymentMethod(
         operationId: id,
         chargeId: chargeId,
@@ -530,7 +560,8 @@ class Terminal {
         metadata: metadata,
         reverseTransfer: reverseTransfer,
         refundApplicationFee: refundApplicationFee,
-        customerCancellationEnabled: isCustomerCancellationEnabled ?? customerCancellationEnabled,
+        customerCancellationEnabled:
+            isCustomerCancellationEnabled ?? customerCancellationEnabled,
       );
     });
   }
@@ -555,12 +586,14 @@ class Terminal {
   /// are also not automatically calculated and must be set in [Cart].
   ///
   /// Note: Only available for the Verifone P400 and BBPOS WisePOS E.
-  Future<void> setReaderDisplay(Cart cart) async => await _platform.setReaderDisplay(cart);
+  Future<void> setReaderDisplay(Cart cart) async =>
+      await _platform.setReaderDisplay(cart);
 
   /// Clears the reader display and resets it to the splash screen.
   ///
   /// Note: Only available for the Verifone P400 and BBPOS WisePOS E.
-  Future<void> clearReaderDisplay() async => await _platform.clearReaderDisplay();
+  Future<void> clearReaderDisplay() async =>
+      await _platform.clearReaderDisplay();
 //endregion
 
   StreamController<T> _handleStream<T>(


### PR DESCRIPTION
## Description

This pull request contains the fix for the following related issue raised a couple of weeks ago: https://github.com/BreX900/mek-packages/issues/50

It appears that the reason why tap to pay wasn't working for connected accounts was due to not being able to set the connected account id when instantiating `LocalMobileConnectionConfigurationBuilder` in the `onConnectMobileReader ` method in **Terminal.swift**. 

The `onConnectMobileReader`  method not accepts an `onBehalfOf` field which is sent to the configuration builder:

```swift
// stripe_terminal/ios/Classes/TerminalPlugin.swift

func onConnectMobileReader(
        _ serialNumber: String,
        _ locationId: String,
        _ autoReconnectOnUnexpectedDisconnect: Bool
        _ autoReconnectOnUnexpectedDisconnect: Bool,
        _ onBehalfOf: String? // <-----
    ) async throws -> ReaderApi {
        let config = LocalMobileConnectionConfigurationBuilder(locationId: locationId)
            .setOnBehalfOf(onBehalfOf) // <-----
            .setAutoReconnectOnUnexpectedDisconnect(autoReconnectOnUnexpectedDisconnect)
            .setAutoReconnectionDelegate(_readerReconnectionDelegate)
 ...
...
```

On the Flutter side the platform api method now looks like this:

```dart
// stripe_terminal/lib/src/platform/terminal_platform.dart

Future<Reader> connectMobileReader(
    String serialNumber, {
    required String locationId,
    required bool autoReconnectOnUnexpectedDisconnect,
    String? onBehalfOf, // <------
});
```

To confirm I did run the following command for generating the code to communicate between Flutter and Android/iOS platforms:

```bash
dart run tool/generate_api.dart
```