### PR TITLE
feat: support loading currency from env

### DIFF
--- a/stripe_terminal/example/.env-example
+++ b/stripe_terminal/example/.env-example
@@ -1,1 +1,2 @@
 STRIPE_SECRET_KEY=sk_test_xxxxxxxxxxxxxxxx
+CURRENCY=gbp

--- a/stripe_terminal/example/example.env
+++ b/stripe_terminal/example/example.env
@@ -1,1 +1,0 @@
-STRIPE_SECRET_KEY="sk_test_xxxxxxxxxxxxxxxx"

--- a/stripe_terminal/example/lib/models/k.dart
+++ b/stripe_terminal/example/lib/models/k.dart
@@ -1,3 +1,5 @@
+const envCurrency = String.fromEnvironment('CURRENCY');
+
 abstract final class K {
-  static const String currency = 'gbp';
+  static const String currency = envCurrency == '' ? 'gbp' : envCurrency;
 }

--- a/stripe_terminal/example/lib/models/k.dart
+++ b/stripe_terminal/example/lib/models/k.dart
@@ -1,5 +1,3 @@
-const envCurrency = String.fromEnvironment('CURRENCY');
-
 abstract final class K {
-  static const String currency = envCurrency == '' ? 'gbp' : envCurrency;
+  static const String currency = String.fromEnvironment('CURRENCY', defaultValue: 'gbp');
 }


### PR DESCRIPTION
Hi @BreX900,
when running the example, I noticed that the `gpb` currency is not supported in Germany and it throws an error. This adds an option to set the currency in the `.env` file. Also, there were two example `.env` files, I removed one of them.
Feel free to let me know if you'd like any changes.