### PR TITLE
chore: ignore `.cxx` folder

### DIFF
--- a/stripe_terminal/example/.gitignore
+++ b/stripe_terminal/example/.gitignore
@@ -33,6 +33,7 @@ migrate_working_dir/
 .pub-cache/
 .pub/
 /build/
+.cxx
 
 # Symbolication related
 app.*.symbols


### PR DESCRIPTION
Hi @BreX900,
as of [Flutter 3.29](https://docs.flutter.dev/release/release-notes/release-notes-3.29.0), android builds generate a `.cxx` folder which should be gitignored (also in the default template). This adds that to the `.gitignore`, as otherwise with every build there are lots of uncommitted build files.
Feel free to let me know if you'd like any changes.