### PR TITLE
docs: update readme and replace `.config.json` with `.env`

### DIFF
--- a/stripe_terminal/example/README.md
+++ b/stripe_terminal/example/README.md
@@ -5,7 +5,7 @@ Demonstrates how to use the stripe_terminal plugin.
 ## Getting Started
 
 1. Create a `.env` file with `STRIPE_SECRET_KEY` [(example file)](.env-example)
-2. Run the app with `--dart-define-from-file=.config.json`, for example:
+2. Run the app with `--dart-define-from-file=.env`, for example:
     ```bash
-    flutter run --dart-define-from-file=.config.json
+    flutter run --dart-define-from-file=.env
     ```


### PR DESCRIPTION
Hi @BreX900,
When first running the example, I was quite confused about the `.config.json` file mentioned in the readme. I got it working by replacing that with `.env`, I assume this is how it is supposed to work?
Feel free to let me know if you'd like any changes.