### PR TITLE
fix: example release build with proguard rules

### DIFF
--- a/stripe_terminal/example/android/app/build.gradle
+++ b/stripe_terminal/example/android/app/build.gradle
@@ -56,6 +56,7 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/stripe_terminal/example/android/app/build.gradle
+++ b/stripe_terminal/example/android/app/build.gradle
@@ -56,7 +56,6 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/stripe_terminal/example/android/app/proguard-rules.pro
+++ b/stripe_terminal/example/android/app/proguard-rules.pro
@@ -1,0 +1,10 @@
+-keep class com.namit.** { *; }
+-keep class java.beans.ConstructorProperties { *; }
+-keep class java.beans.Transient { *; }
+-keep class org.slf4j.impl.StaticLoggerBinder { *; }
+-keep class org.slf4j.impl.StaticMDCBinder { *; }
+
+-dontwarn java.beans.ConstructorProperties
+-dontwarn java.beans.Transient
+-dontwarn org.slf4j.impl.StaticLoggerBinder
+-dontwarn org.slf4j.impl.StaticMDCBinder


### PR DESCRIPTION
Hi @BreX900,
sorry for this many PRs, but I thought I'd rather not have one big so you can see and check the changes more easily 👍
I noticed that the example can't currently be build in release mode, it fails with:
```
ERROR: Missing classes detected while running R8. Please add the missing classes or apply additional keep rules that are generated in /Users/hannes/source/mek-packages/stripe_terminal/example/build/app/outputs/mapping/release/missing_rules.txt.
ERROR: R8: Missing class java.beans.ConstructorProperties (referenced from: void com.fasterxml.jackson.databind.ext.Java7SupportImpl.<init>() and 2 other contexts)
Missing class java.beans.Transient (referenced from: void com.fasterxml.jackson.databind.ext.Java7SupportImpl.<init>() and 1 other context)
Missing class org.slf4j.impl.StaticLoggerBinder (referenced from: void org.slf4j.LoggerFactory.bind() and 3 other contexts)
Missing class org.slf4j.impl.StaticMDCBinder (referenced from: org.slf4j.spi.MDCAdapter org.slf4j.MDC.bwCompatibleGetMDCAdapterFromBinder())
```
This fixes that.
Feel free to let me know if you'd like any changes.