### PR TITLE
fix(terminal): correct Interac Present payment method name

### DIFF
--- a/stripe_terminal/ios/Classes/Api/TerminalApi.swift
+++ b/stripe_terminal/ios/Classes/Api/TerminalApi.swift
@@ -1242,7 +1242,7 @@ struct PaymentMethodOptionsParametersApi {
 enum PaymentMethodTypeApi: Int {
     case cardPresent
     case card
-    case interactPresent
+    case interacPresent
 }
 
 enum PaymentStatusApi: Int {

--- a/stripe_terminal/ios/Classes/Mappings/PaymentIntentMappings.swift
+++ b/stripe_terminal/ios/Classes/Mappings/PaymentIntentMappings.swift
@@ -116,7 +116,7 @@ extension PaymentMethodTypeApi {
             return .cardPresent
         case .card:
             return .card
-        case .interactPresent:
+        case .interacPresent:
             return .interacPresent
         }
     }

--- a/stripe_terminal/lib/src/models/payment_method.dart
+++ b/stripe_terminal/lib/src/models/payment_method.dart
@@ -13,7 +13,7 @@ enum PaymentMethodType {
   card,
 
   /// An Interac Present payment method.
-  interactPresent
+  interacPresent
 }
 
 /// PaymentMethod objects represent your customer’s payment instruments. They can be used with


### PR DESCRIPTION
This PR fixes a typo in the payment method type for Interac Present.

Changes:
- Rename iOS enum case from `interactPresent` to `interacPresent` in `stripe_terminal/ios/Classes/Api/TerminalApi.swift`.
- Update mapping in `stripe_terminal/ios/Classes/Mappings/PaymentIntentMappings.swift`.
- Keep Dart model using the correct `interacPresent` spelling (docstring verified) in `stripe_terminal/lib/src/models/payment_method.dart`.

Context:
The codebase mostly uses `interacPresent`, but a couple of spots used the misspelled variant. This caused mismatches during serialization/mapping on iOS. This change aligns everything to the correct naming and mirrors Stripe's terminology.