### PR TITLE
feat(terminal): added id, ipAddress, and networkStatus fields to the Reader.

### DIFF
--- a/stripe_terminal/CHANGELOG.md
+++ b/stripe_terminal/CHANGELOG.md
@@ -1,4 +1,6 @@
 
+# 4.6.2
+- feat(terminal): Added `id`, `ipAddress`, and `networkStatus` fields to the `Reader` object. Added by [@mahmoud-othmane](https://github.com/mahmoud-othmane).
 
 # 4.6.1
 - feat: added support for optional ios parameters on internet and tap-to-pay connection configurations

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/TerminalApi.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/TerminalApi.kt
@@ -1015,6 +1015,10 @@ enum class LocationStatusApi {
     SET, NOT_SET;
 }
 
+enum class NetworkStatusApi {
+    OFFLINE, ONLINE;
+}
+
 data class PaymentIntentApi(
     val amount: Double,
     val amountCapturable: Double?,
@@ -1193,10 +1197,13 @@ data class ReaderApi(
     val availableUpdate: Boolean,
     val batteryLevel: Double,
     val deviceType: DeviceTypeApi?,
+    val id: String?,
+    val ipAddress: String?,
     val label: String?,
     val location: LocationApi?,
     val locationId: String?,
     val locationStatus: LocationStatusApi?,
+    val networkStatus: NetworkStatusApi?,
     val serialNumber: String,
     val simulated: Boolean,
 ) {
@@ -1205,10 +1212,13 @@ data class ReaderApi(
             availableUpdate,
             batteryLevel,
             deviceType?.ordinal,
+            id,
+            ipAddress,
             label,
             location?.serialize(),
             locationId,
             locationStatus?.ordinal,
+            networkStatus?.ordinal,
             serialNumber,
             simulated,
         )

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/mappings/ReaderMappings.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/mappings/ReaderMappings.kt
@@ -27,6 +27,7 @@ import mek.stripeterminal.api.HandoffDiscoveryConfigurationApi
 import mek.stripeterminal.api.InternetDiscoveryConfigurationApi
 import mek.stripeterminal.api.LocationApi
 import mek.stripeterminal.api.LocationStatusApi
+import mek.stripeterminal.api.NetworkStatusApi
 import mek.stripeterminal.api.ReaderApi
 import mek.stripeterminal.api.ReaderDisplayMessageApi
 import mek.stripeterminal.api.ReaderEventApi
@@ -44,12 +45,15 @@ fun Reader.toApi(): ReaderApi {
         locationStatus = locationStatus.toApi(),
         batteryLevel = batteryLevel?.toDouble() ?: -1.0,
         deviceType = deviceType.toApi(),
+        id = id,
         simulated = isSimulated,
         availableUpdate = availableUpdate?.hasFirmwareUpdate ?: false,
         locationId = location?.id,
         location = location?.toApi(),
         label = label,
-        serialNumber = serialNumber!!
+        serialNumber = serialNumber!!,
+        ipAddress = ipAddress,
+        networkStatus = networkStatus?.toApi()
     )
 }
 
@@ -97,6 +101,14 @@ fun Location.toApi(): LocationApi {
         livemode = livemode,
         metadata = metadata?.toHashMap() ?: hashMapOf()
     )
+}
+
+fun Reader.NetworkStatus.toApi(): NetworkStatusApi? {
+    return when (this) {
+        Reader.NetworkStatus.OFFLINE -> NetworkStatusApi.OFFLINE
+        Reader.NetworkStatus.ONLINE -> NetworkStatusApi.ONLINE
+        Reader.NetworkStatus.UNKNOWN -> null
+    }
 }
 
 fun Address.toApi(): AddressApi {

--- a/stripe_terminal/ios/Classes/Api/TerminalApi.swift
+++ b/stripe_terminal/ios/Classes/Api/TerminalApi.swift
@@ -933,9 +933,9 @@ enum DeviceTypeApi: Int {
     case verifoneM425
     case verifoneM450
     case verifoneP630
-    case verifoneUx700
+    case verifoneUX700
     case verifoneV660pDevkit
-    case verifoneUx700Devkit
+    case verifoneUX700Devkit
 }
 
 enum DisconnectReasonApi: Int {
@@ -1078,6 +1078,11 @@ struct LocationApi {
 enum LocationStatusApi: Int {
     case set
     case notSet
+}
+
+enum NetworkStatusApi: Int {
+    case offline
+    case online
 }
 
 struct PaymentIntentApi {
@@ -1266,10 +1271,13 @@ struct ReaderApi {
     let availableUpdate: Bool
     let batteryLevel: Double
     let deviceType: DeviceTypeApi?
+    let id: String?
+    let ipAddress: String?
     let label: String?
     let location: LocationApi?
     let locationId: String?
     let locationStatus: LocationStatusApi?
+    let networkStatus: NetworkStatusApi?
     let serialNumber: String
     let simulated: Bool
 
@@ -1278,10 +1286,13 @@ struct ReaderApi {
             availableUpdate,
             batteryLevel,
             deviceType?.rawValue,
+            id,
+            ipAddress,
             label,
             location?.serialize(),
             locationId,
             locationStatus?.rawValue,
+            networkStatus?.rawValue,
             serialNumber,
             simulated,
         ]

--- a/stripe_terminal/ios/Classes/Mappings/ReaderMappings.swift
+++ b/stripe_terminal/ios/Classes/Mappings/ReaderMappings.swift
@@ -8,12 +8,15 @@ extension Reader {
             availableUpdate: availableUpdate != nil,
             batteryLevel: batteryLevel?.doubleValue ?? -1.0,
             deviceType: deviceType.toApi(),
+            id: stripeId,
+            ipAddress: ipAddress,
             label: label,
             location: location?.toApi(),
             locationId: locationId,
             locationStatus: locationStatus.toApi(),
+            networkStatus: status.toApi(),
             serialNumber: serialNumber,
-            simulated: simulated
+            simulated: simulated,
         )
     }
 }
@@ -56,6 +59,21 @@ extension LocationStatus {
             return .notSet
         @unknown default:
             fatalError("WTF")
+        }
+    }
+}
+
+extension ReaderNetworkStatus {
+    func toApi() -> NetworkStatusApi? {
+        switch self {
+        case .offline:
+            return .offline
+        case .online:
+            return .online
+        case .unknown:
+            return nil
+        @unknown default:
+            fatalError("ReaderNetworkStatus \(self) not supported.")
         }
     }
 }

--- a/stripe_terminal/lib/src/models/reader.dart
+++ b/stripe_terminal/lib/src/models/reader.dart
@@ -24,7 +24,8 @@ enum ConnectionStatus {
 /// labeled with the reader or reader type to which they apply.
 @DataClass()
 class Reader with _$Reader {
-  // TODO: Add id field
+  /// The reader’s unique identifier.
+  final String? id;
 
   /// Used to tell whether the location field has been set. Note that the Internet and simulated
   /// readers will always have an `null` [locationStatus].
@@ -86,13 +87,19 @@ class Reader with _$Reader {
 
   /// Internet readers properties
 
-  // TODO: Add ipAddress field
-  // TODO: Add status/networkStatus field
+  /// The reader’s IP address, or nil if the IP address is unknown.
+  final String? ipAddress;
+
+  /// The reader’s network status, or nil if the network status is unknown.
+  final NetworkStatus? networkStatus;
+
+  // TODO: Add status field
 
   final String? label;
 
   @internal
   const Reader({
+    required this.id,
     required this.locationStatus,
     required this.batteryLevel,
     required this.deviceType,
@@ -101,6 +108,8 @@ class Reader with _$Reader {
     required this.serialNumber,
     required this.locationId,
     required this.location,
+    required this.ipAddress,
+    required this.networkStatus,
     required this.label,
   });
 }
@@ -255,4 +264,12 @@ enum ReaderInputOption {
 
   /// Manually enter the card information (MOTO).
   manualEntry
+}
+
+enum NetworkStatus {
+  /// The reader is not connected to a network.
+  offline,
+
+  /// The reader is connected to a network.
+  online,
 }

--- a/stripe_terminal/lib/src/platform/terminal_platform.api.dart
+++ b/stripe_terminal/lib/src/platform/terminal_platform.api.dart
@@ -728,12 +728,15 @@ Reader _$deserializeReader(List<Object?> serialized) => Reader(
     availableUpdate: serialized[0] as bool,
     batteryLevel: serialized[1] as double,
     deviceType: serialized[2] != null ? DeviceType.values[serialized[2] as int] : null,
-    label: serialized[3] as String?,
-    location: serialized[4] != null ? _$deserializeLocation(serialized[4] as List) : null,
-    locationId: serialized[5] as String?,
-    locationStatus: serialized[6] != null ? LocationStatus.values[serialized[6] as int] : null,
-    serialNumber: serialized[7] as String,
-    simulated: serialized[8] as bool);
+    id: serialized[3] as String?,
+    ipAddress: serialized[4] as String?,
+    label: serialized[5] as String?,
+    location: serialized[6] != null ? _$deserializeLocation(serialized[6] as List) : null,
+    locationId: serialized[7] as String?,
+    locationStatus: serialized[8] != null ? LocationStatus.values[serialized[8] as int] : null,
+    networkStatus: serialized[9] != null ? NetworkStatus.values[serialized[9] as int] : null,
+    serialNumber: serialized[10] as String,
+    simulated: serialized[11] as bool);
 List<Object?> _$serializeReaderDelegateAbstract(ReaderDelegateAbstract deserialized) =>
     switch (deserialized) {
       MobileReaderDelegate() => _$serializeMobileReaderDelegate(deserialized),


### PR DESCRIPTION
I'm planning to use this package in a project I'm working on, and I noticed that the `Reader` object is missing the `id`, `ipAddress`, and `networkStatus` fields.  
These fields were already marked as TODOs, so I implemented them to complete the `Reader` model and make it consistent with the expected data.
