### PR TITLE
Fix formatting issue in ReaderMappings.swift

### DIFF
--- a/stripe_terminal/ios/Classes/Mappings/ReaderMappings.swift
+++ b/stripe_terminal/ios/Classes/Mappings/ReaderMappings.swift
@@ -16,7 +16,7 @@ extension Reader {
             locationStatus: locationStatus.toApi(),
             networkStatus: status.toApi(),
             serialNumber: serialNumber,
-            simulated: simulated,
+            simulated: simulated
         )
     }
 }


### PR DESCRIPTION
Deleting a trailing comma that was causing a compilation error on  Xcode versions priors to 16.3 https://medium.com/@mi9nxi/swifts-evolution-trailing-commas-in-function-calls-in-xcode-16-3-2947ae5528ef

<img width="512" height="245" alt="image" src="https://github.com/user-attachments/assets/a1189d72-c177-4f43-9745-143659113259" />

I hope this is useful to you [BreX900](https://github.com/BreX900)!