### PR TITLE
feat: upgrade stripe terminal android sdk to 5.1.1

### DIFF
--- a/stripe_terminal/CHANGELOG.md
+++ b/stripe_terminal/CHANGELOG.md
@@ -1,33 +1,48 @@
+## 5.1.1
 
+- feat: bump Android and iOS Stripe Terminal SDKs to `5.1.1`
+- feat: add support for `ConnectionStatus.reconnecting` and new reader device types
+- feat: add support for `DisconnectReason.bluetoothPeerRemovedPairingInformation`
+- change: customer cancellation is enabled by default in collect flows to match SDK defaults
+- build(ios): update minimum supported iOS version to 15.0
 
 ## 4.6.3
-- fix: deleted a trailing comma that was causing a compilation error on  Xcode versions priors to 16.3
+
+- fix: deleted a trailing comma that was causing a compilation error on Xcode versions priors to 16.3
 
 ## 4.6.2
+
 - feat(terminal): Added `id`, `ipAddress`, and `networkStatus` fields to the `Reader` object. Added by [@mahmoud-othmane](https://github.com/mahmoud-othmane).
 - build: bumped `mek_data_class` package to `2.0.0`
 
 ## 4.6.1
+
 - feat: added support for optional ios parameters on internet and tap-to-pay connection configurations
 
 ## 4.6.0
+
 - feat: bumped android and ios sdk version to `4.6.0`
 
 ## 4.4.1
+
 - feat: added `allowRedisplay` param on `collectPaymentMethod` method
 
 ## 4.4.0
+
 - feat: bumped android and ios sdk version to `4.4.0`
 - fix(ios): fixed wrong mapping tap to pay configuration
 - feat(android): configure tap to pay UX. Thanks [@hrueger](https://github.com/hrueger)
 
 ## 4.0.4
+
 - chore(android): when plugin si attached to activity the `Terminal.onCreate` method is called [#104](https://github.com/BreX900/mek-packages/issues/104)
 
 ## 4.0.3
+
 - chore(android): removed permission check when initializing terminal
 
 ## 4.0.2
+
 - build: updated `meta` to `1.15.0` and `one_for_all` to `1.1.1` dependency
 - build: updated `dart` constraints to `>=3.5.0 <4.0.0` and `flutter` to `>=3.24.0`
 - docs: updated README.md file

--- a/stripe_terminal/README.md
+++ b/stripe_terminal/README.md
@@ -202,14 +202,10 @@ You can see the usage example in the [example folder](example/lib/main.dart)
     ```dart
     final paymentIntent = await Terminal.instance.retrievePaymentIntent(backendPaymentIntent.clientSecret);
     ```
-3. Collect payment method
+3. Process payment intent (collect and confirm in one call)
     ```dart
-    final processablePaymentIntent = await Terminal.instance.collectPaymentMethod(paymentIntent);
-    ```
-4. Collect payment method
-    ```dart
-    final capturablePaymentIntent = await Terminal.instance.confirmPaymentIntent(processablePaymentIntent)
-    print("A payment intent has captured a payment method, send this payment intent to you backend to capture the payment");
+    final processedPaymentIntent = await Terminal.instance.processPaymentIntent(paymentIntent);
+    print("Payment processed. Send this PaymentIntent to your backend to capture if needed.");
     ```
 
 ## Contributing

--- a/stripe_terminal/android/build.gradle
+++ b/stripe_terminal/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.7.2'
+
     }
 }
 
@@ -70,8 +71,11 @@ android {
 }
 
 dependencies {
-    implementation "com.stripe:stripeterminal-taptopay:4.6.0"
-    implementation "com.stripe:stripeterminal-core:4.6.0"
+    implementation "com.stripe:stripeterminal-taptopay:5.1.1"
+    implementation "com.stripe:stripeterminal-core:5.1.1"
+    implementation "com.stripe:stripeterminal-appsondevices:5.1.1"
+
+
 }
 
 spotless {

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/TerminalPlugin.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/TerminalPlugin.kt
@@ -32,6 +32,7 @@ import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import mek.stripeterminal.api.AllowRedisplayApi
 import mek.stripeterminal.api.CartApi
+import mek.stripeterminal.api.ClearCachedCredentialsResultApi
 import mek.stripeterminal.api.ConfirmPaymentIntentConfigurationApi
 import mek.stripeterminal.api.ConnectionConfigurationApi
 import mek.stripeterminal.api.ConnectionStatusApi
@@ -125,9 +126,15 @@ class TerminalPlatformPlugin(
         )
     }
 
-    override fun onClearCachedCredentials() {
-        terminal.clearCachedCredentials()
-        clean()
+    override fun onClearCachedCredentials(): ClearCachedCredentialsResultApi {
+        val result = terminal.clearCachedCredentials()
+        if (result.isSuccessful) {
+            clean()
+        }
+        return ClearCachedCredentialsResultApi(
+            isSuccessful = result.isSuccessful,
+            error = result.error?.toApi(),
+        )
     }
 
     // region Reader discovery, connection and updates

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/TerminalPlugin.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/TerminalPlugin.kt
@@ -10,7 +10,6 @@ import com.stripe.stripeterminal.external.callable.PaymentIntentCallback
 import com.stripe.stripeterminal.external.callable.ReaderCallback
 import com.stripe.stripeterminal.external.callable.RefundCallback
 import com.stripe.stripeterminal.external.callable.SetupIntentCallback
-import com.stripe.stripeterminal.external.models.AllowRedisplay
 import com.stripe.stripeterminal.external.models.CollectPaymentIntentConfiguration
 import com.stripe.stripeterminal.external.models.CollectRefundConfiguration
 import com.stripe.stripeterminal.external.models.CollectSetupIntentConfiguration
@@ -26,7 +25,6 @@ import com.stripe.stripeterminal.external.models.RefundParameters
 import com.stripe.stripeterminal.external.models.SetupIntent
 import com.stripe.stripeterminal.external.models.SetupIntentCancellationParameters
 import com.stripe.stripeterminal.external.models.SetupIntentParameters
-import com.stripe.stripeterminal.external.models.Surcharge
 import com.stripe.stripeterminal.external.models.TerminalException
 import com.stripe.stripeterminal.log.LogLevel
 import io.flutter.embedding.engine.plugins.FlutterPlugin

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/TerminalApi.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/TerminalApi.kt
@@ -116,7 +116,7 @@ interface TerminalPlatformApi {
         clientSecret: String,
     )
 
-    fun onStartCollectPaymentMethod(
+    fun onStartProcessPaymentIntent(
         result: Result<PaymentIntentApi>,
         operationId: Long,
         paymentIntentId: String,
@@ -127,20 +127,10 @@ interface TerminalPlatformApi {
         shouldUpdatePaymentIntent: Boolean,
         customerCancellationEnabled: Boolean,
         allowRedisplay: AllowRedisplayApi,
+        confirmConfiguration: ConfirmPaymentIntentConfigurationApi?,
     )
 
-    fun onStopCollectPaymentMethod(
-        result: Result<Unit>,
-        operationId: Long,
-    )
-
-    fun onStartConfirmPaymentIntent(
-        result: Result<PaymentIntentApi>,
-        operationId: Long,
-        paymentIntentId: String,
-    )
-
-    fun onStopConfirmPaymentIntent(
+    fun onStopProcessPaymentIntent(
         result: Result<Unit>,
         operationId: Long,
     )
@@ -164,7 +154,7 @@ interface TerminalPlatformApi {
         clientSecret: String,
     )
 
-    fun onStartCollectSetupIntentPaymentMethod(
+    fun onStartProcessSetupIntent(
         result: Result<SetupIntentApi>,
         operationId: Long,
         setupIntentId: String,
@@ -172,18 +162,7 @@ interface TerminalPlatformApi {
         customerCancellationEnabled: Boolean,
     )
 
-    fun onStopCollectSetupIntentPaymentMethod(
-        result: Result<Unit>,
-        operationId: Long,
-    )
-
-    fun onStartConfirmSetupIntent(
-        result: Result<SetupIntentApi>,
-        operationId: Long,
-        setupIntentId: String,
-    )
-
-    fun onStopConfirmSetupIntent(
+    fun onStopProcessSetupIntent(
         result: Result<Unit>,
         operationId: Long,
     )
@@ -193,10 +172,12 @@ interface TerminalPlatformApi {
         setupIntentId: String,
     )
 
-    fun onStartCollectRefundPaymentMethod(
-        result: Result<Unit>,
+    fun onStartProcessRefund(
+        result: Result<RefundApi>,
         operationId: Long,
-        chargeId: String,
+        chargeId: String?,
+        paymentIntentId: String?,
+        paymentIntentClientSecret: String?,
         amount: Long,
         currency: String,
         metadata: HashMap<String, String>?,
@@ -205,17 +186,7 @@ interface TerminalPlatformApi {
         customerCancellationEnabled: Boolean,
     )
 
-    fun onStopCollectRefundPaymentMethod(
-        result: Result<Unit>,
-        operationId: Long,
-    )
-
-    fun onStartConfirmRefund(
-        result: Result<RefundApi>,
-        operationId: Long,
-    )
-
-    fun onStopConfirmRefund(
+    fun onStopProcessRefund(
         result: Result<Unit>,
         operationId: Long,
     )
@@ -231,6 +202,17 @@ interface TerminalPlatformApi {
 
     fun onSetTapToPayUXConfiguration(
         configuration: TapToPayUxConfigurationApi,
+    )
+
+    fun onStartEasyConnect(
+        result: Result<ReaderApi>,
+        operationId: Long,
+        configuration: EasyConnectConfigurationApi,
+    )
+
+    fun onStopEasyConnect(
+        result: Result<Unit>,
+        operationId: Long,
     )
 
     private fun onMethodCall(
@@ -310,21 +292,13 @@ interface TerminalPlatformApi {
                     val res = Result<PaymentIntentApi>(result) { it.serialize() }
                     onRetrievePaymentIntent(res, args[0] as String)
                 }
-                "startCollectPaymentMethod" -> {
+                "startProcessPaymentIntent" -> {
                     val res = Result<PaymentIntentApi>(result) { it.serialize() }
-                    onStartCollectPaymentMethod(res, (args[0] as Number).toLong(), args[1] as String, args[2] as Boolean, args[3] as String?, args[4] as Boolean, (args[5] as List<Any?>?)?.let { TippingConfigurationApi.deserialize(it) }, args[6] as Boolean, args[7] as Boolean, (args[8] as Int).let { AllowRedisplayApi.values()[it] })
+                    onStartProcessPaymentIntent(res, (args[0] as Number).toLong(), args[1] as String, args[2] as Boolean, args[3] as String?, args[4] as Boolean, (args[5] as List<Any?>?)?.let { TippingConfigurationApi.deserialize(it) }, args[6] as Boolean, args[7] as Boolean, (args[8] as Int).let { AllowRedisplayApi.values()[it] }, (args[9] as List<Any?>?)?.let { ConfirmPaymentIntentConfigurationApi.deserialize(it) })
                 }
-                "stopCollectPaymentMethod" -> {
+                "stopProcessPaymentIntent" -> {
                     val res = Result<Unit>(result) { null }
-                    onStopCollectPaymentMethod(res, (args[0] as Number).toLong())
-                }
-                "startConfirmPaymentIntent" -> {
-                    val res = Result<PaymentIntentApi>(result) { it.serialize() }
-                    onStartConfirmPaymentIntent(res, (args[0] as Number).toLong(), args[1] as String)
-                }
-                "stopConfirmPaymentIntent" -> {
-                    val res = Result<Unit>(result) { null }
-                    onStopConfirmPaymentIntent(res, (args[0] as Number).toLong())
+                    onStopProcessPaymentIntent(res, (args[0] as Number).toLong())
                 }
                 "cancelPaymentIntent" -> {
                     val res = Result<PaymentIntentApi>(result) { it.serialize() }
@@ -338,41 +312,25 @@ interface TerminalPlatformApi {
                     val res = Result<SetupIntentApi>(result) { it.serialize() }
                     onRetrieveSetupIntent(res, args[0] as String)
                 }
-                "startCollectSetupIntentPaymentMethod" -> {
+                "startProcessSetupIntent" -> {
                     val res = Result<SetupIntentApi>(result) { it.serialize() }
-                    onStartCollectSetupIntentPaymentMethod(res, (args[0] as Number).toLong(), args[1] as String, (args[2] as Int).let { AllowRedisplayApi.values()[it] }, args[3] as Boolean)
+                    onStartProcessSetupIntent(res, (args[0] as Number).toLong(), args[1] as String, (args[2] as Int).let { AllowRedisplayApi.values()[it] }, args[3] as Boolean)
                 }
-                "stopCollectSetupIntentPaymentMethod" -> {
+                "stopProcessSetupIntent" -> {
                     val res = Result<Unit>(result) { null }
-                    onStopCollectSetupIntentPaymentMethod(res, (args[0] as Number).toLong())
-                }
-                "startConfirmSetupIntent" -> {
-                    val res = Result<SetupIntentApi>(result) { it.serialize() }
-                    onStartConfirmSetupIntent(res, (args[0] as Number).toLong(), args[1] as String)
-                }
-                "stopConfirmSetupIntent" -> {
-                    val res = Result<Unit>(result) { null }
-                    onStopConfirmSetupIntent(res, (args[0] as Number).toLong())
+                    onStopProcessSetupIntent(res, (args[0] as Number).toLong())
                 }
                 "cancelSetupIntent" -> {
                     val res = Result<SetupIntentApi>(result) { it.serialize() }
                     onCancelSetupIntent(res, args[0] as String)
                 }
-                "startCollectRefundPaymentMethod" -> {
-                    val res = Result<Unit>(result) { null }
-                    onStartCollectRefundPaymentMethod(res, (args[0] as Number).toLong(), args[1] as String, (args[2] as Number).toLong(), args[3] as String, args[4]?.let { hashMapOf(*(it as HashMap<*, *>).map { (k, v) -> k as String to v as String }.toTypedArray()) }, args[5] as Boolean?, args[6] as Boolean?, args[7] as Boolean)
-                }
-                "stopCollectRefundPaymentMethod" -> {
-                    val res = Result<Unit>(result) { null }
-                    onStopCollectRefundPaymentMethod(res, (args[0] as Number).toLong())
-                }
-                "startConfirmRefund" -> {
+                "startProcessRefund" -> {
                     val res = Result<RefundApi>(result) { it.serialize() }
-                    onStartConfirmRefund(res, (args[0] as Number).toLong())
+                    onStartProcessRefund(res, (args[0] as Number).toLong(), args[1] as String?, args[2] as String?, args[3] as String?, (args[4] as Number).toLong(), args[5] as String, args[6]?.let { hashMapOf(*(it as HashMap<*, *>).map { (k, v) -> k as String to v as String }.toTypedArray()) }, args[7] as Boolean?, args[8] as Boolean?, args[9] as Boolean)
                 }
-                "stopConfirmRefund" -> {
+                "stopProcessRefund" -> {
                     val res = Result<Unit>(result) { null }
-                    onStopConfirmRefund(res, (args[0] as Number).toLong())
+                    onStopProcessRefund(res, (args[0] as Number).toLong())
                 }
                 "setReaderDisplay" -> {
                     val res = Result<Unit>(result) { null }
@@ -385,6 +343,14 @@ interface TerminalPlatformApi {
                 "setTapToPayUXConfiguration" -> {
                     onSetTapToPayUXConfiguration((args[0] as List<Any?>).let { TapToPayUxConfigurationApi.deserialize(it) })
                     result.success(null)
+                }
+                "startEasyConnect" -> {
+                    val res = Result<ReaderApi>(result) { it.serialize() }
+                    onStartEasyConnect(res, (args[0] as Number).toLong(), (args[1] as List<Any?>).let { EasyConnectConfigurationApi.deserialize(it) })
+                }
+                "stopEasyConnect" -> {
+                    val res = Result<Unit>(result) { null }
+                    onStopEasyConnect(res, (args[0] as Number).toLong())
                 }
             }
         } catch (e: PlatformError) {
@@ -766,6 +732,20 @@ enum class ChargeStatusApi {
     SUCCEEDED, PENDING, FAILED;
 }
 
+data class ConfirmPaymentIntentConfigurationApi(
+    val returnUrl: String?,
+) {
+    companion object {
+        fun deserialize(
+            serialized: List<Any?>,
+        ): ConfirmPaymentIntentConfigurationApi {
+            return ConfirmPaymentIntentConfigurationApi(
+                returnUrl = serialized[0] as String?,
+            )
+        }
+    }
+}
+
 enum class ConfirmationMethodApi {
     AUTOMATIC, MANUAL;
 }
@@ -777,6 +757,7 @@ sealed class ConnectionConfigurationApi {
         ): ConnectionConfigurationApi {
             return when (serialized[0]) {
                 "BluetoothConnectionConfiguration" -> BluetoothConnectionConfigurationApi.deserialize(serialized.drop(1))
+                "AppsOnDevicesConnectionConfiguration" -> AppsOnDevicesConnectionConfigurationApi.deserialize(serialized.drop(1))
                 "HandoffConnectionConfiguration" -> HandoffConnectionConfigurationApi.deserialize(serialized.drop(1))
                 "InternetConnectionConfiguration" -> InternetConnectionConfigurationApi.deserialize(serialized.drop(1))
                 "TapToPayConnectionConfiguration" -> TapToPayConnectionConfigurationApi.deserialize(serialized.drop(1))
@@ -798,6 +779,17 @@ data class BluetoothConnectionConfigurationApi(
             return BluetoothConnectionConfigurationApi(
                 autoReconnectOnUnexpectedDisconnect = serialized[0] as Boolean,
                 locationId = serialized[1] as String,
+            )
+        }
+    }
+}
+
+class AppsOnDevicesConnectionConfigurationApi: ConnectionConfigurationApi() {
+    companion object {
+        fun deserialize(
+            serialized: List<Any?>,
+        ): AppsOnDevicesConnectionConfigurationApi {
+            return AppsOnDevicesConnectionConfigurationApi(
             )
         }
     }
@@ -871,15 +863,15 @@ data class UsbConnectionConfigurationApi(
 }
 
 enum class ConnectionStatusApi {
-    NOT_CONNECTED, CONNECTED, CONNECTING, DISCOVERING;
+    NOT_CONNECTED, CONNECTED, CONNECTING, DISCOVERING, RECONNECTING;
 }
 
 enum class DeviceTypeApi {
-    CHIPPER1_X, CHIPPER2_X, STRIPE_M2, TAP_TO_PAY, VERIFONE_P400, WISE_CUBE, WISE_PAD3, WISE_PAD3S, WISE_POS_E, WISE_POS_E_DEVKIT, ETNA, STRIPE_S700, STRIPE_S700_DEVKIT, STRIPE_S710, STRIPE_S710_DEVKIT, VERIFONE_V660P, VERIFONE_M425, VERIFONE_M450, VERIFONE_P630, VERIFONE_UX700, VERIFONE_V660P_DEVKIT, VERIFONE_UX700_DEVKIT;
+    CHIPPER1_X, CHIPPER2_X, STRIPE_M2, TAP_TO_PAY, VERIFONE_P400, WISE_CUBE, WISE_PAD3, WISE_PAD3S, WISE_POS_E, WISE_POS_E_DEVKIT, ETNA, STRIPE_S700, STRIPE_S700_DEVKIT, STRIPE_S710, STRIPE_S710_DEVKIT, STRIPE_T600, STRIPE_T600_DEVKIT, STRIPE_T610, STRIPE_T610_DEVKIT, VERIFONE_V660P, VERIFONE_V660PA, VERIFONE_M425, VERIFONE_M450, VERIFONE_P630, VERIFONE_UX700, VERIFONE_V660P_DEVKIT, VERIFONE_UX700_DEVKIT, VERIFONE_VM100, VERIFONE_VP100;
 }
 
 enum class DisconnectReasonApi {
-    UNKNOWN, DISCONNECT_REQUESTED, REBOOT_REQUESTED, SECURITY_REBOOT, CRITICALLY_LOW_BATTERY, POWERED_OFF, BLUETOOTH_DISABLED, USB_DISCONNECTED, IDLE_POWER_DOWN, BLUETOOTH_SIGNAL_LOST;
+    UNKNOWN, DISCONNECT_REQUESTED, REBOOT_REQUESTED, SECURITY_REBOOT, CRITICALLY_LOW_BATTERY, POWERED_OFF, BLUETOOTH_DISABLED, USB_DISCONNECTED, IDLE_POWER_DOWN, BLUETOOTH_SIGNAL_LOST, BLUETOOTH_PEER_REMOVED_PAIRING_INFORMATION;
 }
 
 sealed class DiscoveryConfigurationApi {
@@ -890,6 +882,7 @@ sealed class DiscoveryConfigurationApi {
             return when (serialized[0]) {
                 "BluetoothDiscoveryConfiguration" -> BluetoothDiscoveryConfigurationApi.deserialize(serialized.drop(1))
                 "BluetoothProximityDiscoveryConfiguration" -> BluetoothProximityDiscoveryConfigurationApi.deserialize(serialized.drop(1))
+                "AppsOnDevicesDiscoveryConfiguration" -> AppsOnDevicesDiscoveryConfigurationApi.deserialize(serialized.drop(1))
                 "HandoffDiscoveryConfiguration" -> HandoffDiscoveryConfigurationApi.deserialize(serialized.drop(1))
                 "InternetDiscoveryConfiguration" -> InternetDiscoveryConfigurationApi.deserialize(serialized.drop(1))
                 "TapToPayDiscoveryConfiguration" -> TapToPayDiscoveryConfigurationApi.deserialize(serialized.drop(1))
@@ -930,6 +923,17 @@ data class BluetoothProximityDiscoveryConfigurationApi(
     }
 }
 
+class AppsOnDevicesDiscoveryConfigurationApi: DiscoveryConfigurationApi() {
+    companion object {
+        fun deserialize(
+            serialized: List<Any?>,
+        ): AppsOnDevicesDiscoveryConfigurationApi {
+            return AppsOnDevicesDiscoveryConfigurationApi(
+            )
+        }
+    }
+}
+
 class HandoffDiscoveryConfigurationApi: DiscoveryConfigurationApi() {
     companion object {
         fun deserialize(
@@ -942,6 +946,7 @@ class HandoffDiscoveryConfigurationApi: DiscoveryConfigurationApi() {
 }
 
 data class InternetDiscoveryConfigurationApi(
+    val discoveryFilter: DiscoveryFilterApi?,
     val isSimulated: Boolean,
     val locationId: String?,
     val timeout: Long?,
@@ -951,9 +956,10 @@ data class InternetDiscoveryConfigurationApi(
             serialized: List<Any?>,
         ): InternetDiscoveryConfigurationApi {
             return InternetDiscoveryConfigurationApi(
-                isSimulated = serialized[0] as Boolean,
-                locationId = serialized[1] as String?,
-                timeout = serialized[2] as Long?,
+                discoveryFilter = (serialized[0] as List<Any?>?)?.let { DiscoveryFilterApi.deserialize(it) },
+                isSimulated = serialized[1] as Boolean,
+                locationId = serialized[2] as String?,
+                timeout = serialized[3] as Long?,
             )
         }
     }
@@ -984,6 +990,113 @@ data class UsbDiscoveryConfigurationApi(
             return UsbDiscoveryConfigurationApi(
                 isSimulated = serialized[0] as Boolean,
                 timeout = serialized[1] as Long?,
+            )
+        }
+    }
+}
+
+sealed class DiscoveryFilterApi {
+    companion object {
+        fun deserialize(
+            serialized: List<Any?>,
+        ): DiscoveryFilterApi {
+            return when (serialized[0]) {
+                "DiscoveryFilterByReaderId" -> DiscoveryFilterByReaderIdApi.deserialize(serialized.drop(1))
+                "DiscoveryFilterBySerialNumber" -> DiscoveryFilterBySerialNumberApi.deserialize(serialized.drop(1))
+                else -> throw Error()
+            }
+        }
+    }
+}
+
+data class DiscoveryFilterByReaderIdApi(
+    val readerId: String,
+): DiscoveryFilterApi() {
+    companion object {
+        fun deserialize(
+            serialized: List<Any?>,
+        ): DiscoveryFilterByReaderIdApi {
+            return DiscoveryFilterByReaderIdApi(
+                readerId = serialized[0] as String,
+            )
+        }
+    }
+}
+
+
+data class DiscoveryFilterBySerialNumberApi(
+    val serialNumber: String,
+): DiscoveryFilterApi() {
+    companion object {
+        fun deserialize(
+            serialized: List<Any?>,
+        ): DiscoveryFilterBySerialNumberApi {
+            return DiscoveryFilterBySerialNumberApi(
+                serialNumber = serialized[0] as String,
+            )
+        }
+    }
+}
+
+
+sealed class EasyConnectConfigurationApi {
+    companion object {
+        fun deserialize(
+            serialized: List<Any?>,
+        ): EasyConnectConfigurationApi {
+            return when (serialized[0]) {
+                "InternetEasyConnectConfiguration" -> InternetEasyConnectConfigurationApi.deserialize(serialized.drop(1))
+                "AppsOnDevicesEasyConnectionConfiguration" -> AppsOnDevicesEasyConnectionConfigurationApi.deserialize(serialized.drop(1))
+                "TapToPayEasyConnectConfiguration" -> TapToPayEasyConnectConfigurationApi.deserialize(serialized.drop(1))
+                else -> throw Error()
+            }
+        }
+    }
+}
+
+data class InternetEasyConnectConfigurationApi(
+    val connectionConfiguration: InternetConnectionConfigurationApi,
+    val discoveryConfiguration: InternetDiscoveryConfigurationApi,
+): EasyConnectConfigurationApi() {
+    companion object {
+        fun deserialize(
+            serialized: List<Any?>,
+        ): InternetEasyConnectConfigurationApi {
+            return InternetEasyConnectConfigurationApi(
+                connectionConfiguration = (serialized[0] as List<Any?>).let { InternetConnectionConfigurationApi.deserialize(it) },
+                discoveryConfiguration = (serialized[1] as List<Any?>).let { InternetDiscoveryConfigurationApi.deserialize(it) },
+            )
+        }
+    }
+}
+
+data class AppsOnDevicesEasyConnectionConfigurationApi(
+    val connectionConfiguration: AppsOnDevicesConnectionConfigurationApi,
+    val discoveryConfiguration: AppsOnDevicesDiscoveryConfigurationApi,
+): EasyConnectConfigurationApi() {
+    companion object {
+        fun deserialize(
+            serialized: List<Any?>,
+        ): AppsOnDevicesEasyConnectionConfigurationApi {
+            return AppsOnDevicesEasyConnectionConfigurationApi(
+                connectionConfiguration = (serialized[0] as List<Any?>).let { AppsOnDevicesConnectionConfigurationApi.deserialize(it) },
+                discoveryConfiguration = (serialized[1] as List<Any?>).let { AppsOnDevicesDiscoveryConfigurationApi.deserialize(it) },
+            )
+        }
+    }
+}
+
+data class TapToPayEasyConnectConfigurationApi(
+    val connectionConfiguration: TapToPayConnectionConfigurationApi,
+    val discoveryConfiguration: TapToPayDiscoveryConfigurationApi,
+): EasyConnectConfigurationApi() {
+    companion object {
+        fun deserialize(
+            serialized: List<Any?>,
+        ): TapToPayEasyConnectConfigurationApi {
+            return TapToPayEasyConnectConfigurationApi(
+                connectionConfiguration = (serialized[0] as List<Any?>).let { TapToPayConnectionConfigurationApi.deserialize(it) },
+                discoveryConfiguration = (serialized[1] as List<Any?>).let { TapToPayDiscoveryConfigurationApi.deserialize(it) },
             )
         }
     }
@@ -1232,6 +1345,7 @@ sealed class ReaderDelegateAbstractApi {
         ): ReaderDelegateAbstractApi {
             return when (serialized[0]) {
                 "MobileReaderDelegate" -> MobileReaderDelegateApi.deserialize(serialized.drop(1))
+                "AppsOnDevicesReaderDelegate" -> AppsOnDevicesReaderDelegateApi.deserialize(serialized.drop(1))
                 "HandoffReaderDelegate" -> HandoffReaderDelegateApi.deserialize(serialized.drop(1))
                 "InternetReaderDelegate" -> InternetReaderDelegateApi.deserialize(serialized.drop(1))
                 "TapToPayReaderDelegate" -> TapToPayReaderDelegateApi.deserialize(serialized.drop(1))
@@ -1247,6 +1361,17 @@ class MobileReaderDelegateApi: ReaderDelegateAbstractApi() {
             serialized: List<Any?>,
         ): MobileReaderDelegateApi {
             return MobileReaderDelegateApi(
+            )
+        }
+    }
+}
+
+class AppsOnDevicesReaderDelegateApi: ReaderDelegateAbstractApi() {
+    companion object {
+        fun deserialize(
+            serialized: List<Any?>,
+        ): AppsOnDevicesReaderDelegateApi {
+            return AppsOnDevicesReaderDelegateApi(
             )
         }
     }
@@ -1558,7 +1683,7 @@ data class TapToPayUxConfigurationTapZoneApi(
 }
 
 enum class TapToPayUxConfigurationTapZoneIndicatorApi {
-    ABOVE, BELOW, FRONT, BEHIND;
+    ABOVE, BELOW, FRONT, BEHIND, LEFT, RIGHT;
 }
 
 data class TapToPayUxConfigurationTapZonePositionApi(
@@ -1596,7 +1721,7 @@ data class TerminalExceptionApi(
 }
 
 enum class TerminalExceptionCodeApi {
-    UNKNOWN, READER_NOT_RECOVERED, PAYMENT_INTENT_NOT_RECOVERED, SETUP_INTENT_NOT_RECOVERED, CANCEL_FAILED, CANCEL_FAILED_UNAVAILABLE, NOT_CONNECTED_TO_READER, ALREADY_CONNECTED_TO_READER, BLUETOOTH_DISABLED, BLUETOOTH_PERMISSION_DENIED, CONFIRM_INVALID_PAYMENT_INTENT, CONFIRM_INVALID_SETUP_INTENT, INVALID_CLIENT_SECRET, INVALID_READER_FOR_UPDATE, UNSUPPORTED_OPERATION, UNEXPECTED_OPERATION, UNSUPPORTED_SDK, FEATURE_NOT_AVAILABLE_WITH_CONNECTED_READER, USB_PERMISSION_DENIED, USB_DISCOVERY_TIMED_OUT, INVALID_PARAMETER, REQUEST_DYNAMIC_CURRENCY_CONVERSION_REQUIRES_UPDATE_PAYMENT_INTENT, DYNAMIC_CURRENCY_CONVERSION_NOT_AVAILABLE, INVALID_REQUIRED_PARAMETER, INVALID_TIP_PARAMETER, TAP_TO_PAY_UNSUPPORTED_DEVICE, TAP_TO_PAY_UNSUPPORTED_OPERATING_SYSTEM_VERSION, TAP_TO_PAY_DEVICE_TAMPERED, TAP_TO_PAY_DEBUG_NOT_SUPPORTED, TAP_TO_PAY_INSECURE_ENVIRONMENT, OFFLINE_MODE_UNSUPPORTED_OPERATING_SYSTEM_VERSION, CANCELED, LOCATION_SERVICES_DISABLED, BLUETOOTH_SCAN_TIMED_OUT, BLUETOOTH_LOW_ENERGY_UNSUPPORTED, READER_SOFTWARE_UPDATE_FAILED_BATTERY_LOW, READER_SOFTWARE_UPDATE_FAILED_INTERRUPTED, READER_SOFTWARE_UPDATE_FAILED_EXPIRED_UPDATE, READER_BATTERY_CRITICALLY_LOW, CARD_INSERT_NOT_READ, CARD_SWIPE_NOT_READ, CARD_READ_TIMED_OUT, CARD_REMOVED, CUSTOMER_CONSENT_REQUIRED, CARD_LEFT_IN_READER, FEATURE_NOT_ENABLED_ON_ACCOUNT, PASSCODE_NOT_ENABLED, COMMAND_NOT_ALLOWED_DURING_CALL, INVALID_AMOUNT, INVALID_CURRENCY, TAP_TO_PAY_READER_T_O_S_ACCEPTANCE_REQUIRESI_CLOUD_SIGN_IN, TAP_TO_PAY_READER_T_O_S_ACCEPTANCE_CANCELED, TAP_TO_PAY_READER_FAILED_TO_PREPARE, TAP_TO_PAY_READER_DEVICE_BANNED, TAP_TO_PAY_READER_T_O_S_NOT_YET_ACCEPTED, TAP_TO_PAY_READER_T_O_S_ACCEPTANCE_FAILED, TAP_TO_PAY_READER_MERCHANT_BLOCKED, TAP_TO_PAY_READER_INVALID_MERCHANT, TAP_TO_PAY_READER_ACCOUNT_DEACTIVATED, READER_MISSING_ENCRYPTION_KEYS, READER_BUSY, INCOMPATIBLE_READER, READER_COMMUNICATION_ERROR, READER_TAMPERED, UNKNOWN_READER_IP_ADDRESS, INTERNET_CONNECT_TIME_OUT, CONNECT_FAILED_READER_IS_IN_USE, READER_NOT_ACCESSIBLE_IN_BACKGROUND, BLUETOOTH_ERROR, BLUETOOTH_CONNECT_TIMED_OUT, BLUETOOTH_DISCONNECTED, BLUETOOTH_PEER_REMOVED_PAIRING_INFORMATION, BLUETOOTH_ALREADY_PAIRED_WITH_ANOTHER_DEVICE, BLUETOOTH_RECONNECT_STARTED, USB_DISCONNECTED, USB_RECONNECT_STARTED, READER_CONNECTED_TO_ANOTHER_DEVICE, READER_SOFTWARE_UPDATE_FAILED, READER_SOFTWARE_UPDATE_FAILED_READER_ERROR, READER_SOFTWARE_UPDATE_FAILED_SERVER_ERROR, NFC_DISABLED, UNSUPPORTED_READER_VERSION, UNEXPECTED_SDK_ERROR, UNEXPECTED_READER_ERROR, ENCRYPTION_KEY_FAILURE, ENCRYPTION_KEY_STILL_INITIALIZING, DECLINED_BY_STRIPE_API, DECLINED_BY_READER, COMMAND_INVALID_ALLOW_REDISPLAY, NOT_CONNECTED_TO_INTERNET, REQUEST_TIMED_OUT, STRIPE_API_CONNECTION_ERROR, STRIPE_API_ERROR, STRIPE_API_RESPONSE_DECODING_ERROR, INTERNAL_NETWORK_ERROR, CONNECTION_TOKEN_PROVIDER_ERROR, SESSION_EXPIRED, UNSUPPORTED_MOBILE_DEVICE_CONFIGURATION, COMMAND_NOT_ALLOWED, AMOUNT_EXCEEDS_MAX_OFFLINE_AMOUNT, OFFLINE_PAYMENTS_DATABASE_TOO_LARGE, READER_CONNECTION_NOT_AVAILABLE_OFFLINE, READER_CONNECTION_OFFLINE_LOCATION_MISMATCH, READER_CONNECTION_OFFLINE_NEEDS_UPDATE, LOCATION_CONNECTION_NOT_AVAILABLE_OFFLINE, NO_LAST_SEEN_ACCOUNT, INVALID_OFFLINE_CURRENCY, REFUND_FAILED, CARD_SWIPE_NOT_AVAILABLE, INTERAC_NOT_SUPPORTED_OFFLINE, ONLINE_PIN_NOT_SUPPORTED_OFFLINE, MOBILE_WALLET_NOT_SUPPORTED_ON_SETUP_INTENTS, OFFLINE_AND_CARD_EXPIRED, OFFLINE_TRANSACTION_DECLINED, OFFLINE_COLLECT_AND_CONFIRM_MISMATCH, FORWARDING_TEST_MODE_PAYMENT_IN_LIVE_MODE, FORWARDING_LIVE_MODE_PAYMENT_IN_TEST_MODE, OFFLINE_PAYMENT_INTENT_NOT_FOUND, UPDATE_PAYMENT_INTENT_UNAVAILABLE_WHILE_OFFLINE, UPDATE_PAYMENT_INTENT_UNAVAILABLE_WHILE_OFFLINE_MODE_ENABLED, MISSING_EMV_DATA, CONNECTION_TOKEN_PROVIDER_ERROR_WHILE_FORWARDING, CONNECTION_TOKEN_PROVIDER_TIMED_OUT, ACCOUNT_ID_MISMATCH_WHILE_FORWARDING, OFFLINE_BEHAVIOR_FORCE_OFFLINE_WITH_FEATURE_DISABLED, NOT_CONNECTED_TO_INTERNET_AND_OFFLINE_BEHAVIOR_REQUIRE_ONLINE, TEST_CARD_IN_LIVE_MODE, COLLECT_INPUTS_APPLICATION_ERROR, COLLECT_INPUTS_TIMED_OUT, CANCELED_DUE_TO_INTEGRATION_ERROR, PRINTER_BUSY, PRINTER_PAPERJAM, PRINTER_OUT_OF_PAPER, PRINTER_COVER_OPEN, PRINTER_ABSENT, PRINTER_UNAVAILABLE, PRINTER_ERROR, COLLECT_INPUTS_UNSUPPORTED, READER_SETTINGS_ERROR, INVALID_SURCHARGE_PARAMETER, READER_COMMUNICATION_SSL_ERROR, ALLOW_REDISPLAY_INVALID, SURCHARGING_NOT_AVAILABLE, SURCHARGE_NOTICE_REQUIRES_UPDATE_PAYMENT_INTENT, SURCHARGE_UNAVAILABLE_WITH_DYNAMIC_CURRENCY_CONVERSION, TAP_TO_PAY_UNSUPPORTED_PROCESSOR;
+    UNKNOWN, READER_NOT_RECOVERED, PAYMENT_INTENT_NOT_RECOVERED, SETUP_INTENT_NOT_RECOVERED, CANCEL_FAILED, CANCEL_FAILED_UNAVAILABLE, NOT_CONNECTED_TO_READER, ALREADY_CONNECTED_TO_READER, BLUETOOTH_DISABLED, BLUETOOTH_PERMISSION_DENIED, CONFIRM_INVALID_PAYMENT_INTENT, CONFIRM_INVALID_SETUP_INTENT, INVALID_CLIENT_SECRET, INVALID_READER_FOR_UPDATE, UNSUPPORTED_OPERATION, UNEXPECTED_OPERATION, UNSUPPORTED_SDK, FEATURE_NOT_AVAILABLE_WITH_CONNECTED_READER, USB_PERMISSION_DENIED, USB_DISCOVERY_TIMED_OUT, INVALID_PARAMETER, REQUEST_DYNAMIC_CURRENCY_CONVERSION_REQUIRES_UPDATE_PAYMENT_INTENT, DYNAMIC_CURRENCY_CONVERSION_NOT_AVAILABLE, INVALID_REQUIRED_PARAMETER, INVALID_TIP_PARAMETER, TAP_TO_PAY_UNSUPPORTED_DEVICE, TAP_TO_PAY_UNSUPPORTED_OPERATING_SYSTEM_VERSION, TAP_TO_PAY_DEVICE_TAMPERED, TAP_TO_PAY_DEBUG_NOT_SUPPORTED, TAP_TO_PAY_INSECURE_ENVIRONMENT, OFFLINE_MODE_UNSUPPORTED_OPERATING_SYSTEM_VERSION, CANCELED, LOCATION_SERVICES_DISABLED, BLUETOOTH_SCAN_TIMED_OUT, BLUETOOTH_LOW_ENERGY_UNSUPPORTED, READER_SOFTWARE_UPDATE_FAILED_BATTERY_LOW, READER_SOFTWARE_UPDATE_FAILED_INTERRUPTED, READER_SOFTWARE_UPDATE_FAILED_EXPIRED_UPDATE, READER_BATTERY_CRITICALLY_LOW, CARD_INSERT_NOT_READ, CARD_SWIPE_NOT_READ, CARD_READ_TIMED_OUT, CARD_REMOVED, CUSTOMER_CONSENT_REQUIRED, CARD_LEFT_IN_READER, FEATURE_NOT_ENABLED_ON_ACCOUNT, PASSCODE_NOT_ENABLED, COMMAND_NOT_ALLOWED_DURING_CALL, INVALID_AMOUNT, INVALID_CURRENCY, TAP_TO_PAY_READER_T_O_S_ACCEPTANCE_REQUIRESI_CLOUD_SIGN_IN, TAP_TO_PAY_READER_T_O_S_ACCEPTANCE_CANCELED, TAP_TO_PAY_READER_FAILED_TO_PREPARE, TAP_TO_PAY_READER_DEVICE_BANNED, TAP_TO_PAY_READER_T_O_S_NOT_YET_ACCEPTED, TAP_TO_PAY_READER_T_O_S_ACCEPTANCE_FAILED, TAP_TO_PAY_READER_MERCHANT_BLOCKED, TAP_TO_PAY_READER_INVALID_MERCHANT, TAP_TO_PAY_READER_ACCOUNT_DEACTIVATED, READER_MISSING_ENCRYPTION_KEYS,INVALID_SURCHARGE_PARAMETER,  READER_BUSY, INCOMPATIBLE_READER, READER_COMMUNICATION_ERROR, READER_TAMPERED, UNKNOWN_READER_IP_ADDRESS, INTERNET_CONNECT_TIME_OUT, CONNECT_FAILED_READER_IS_IN_USE, READER_NOT_ACCESSIBLE_IN_BACKGROUND, BLUETOOTH_ERROR, BLUETOOTH_CONNECT_TIMED_OUT, BLUETOOTH_DISCONNECTED, BLUETOOTH_PEER_REMOVED_PAIRING_INFORMATION, BLUETOOTH_ALREADY_PAIRED_WITH_ANOTHER_DEVICE, BLUETOOTH_RECONNECT_STARTED, USB_DISCONNECTED, USB_RECONNECT_STARTED, READER_CONNECTED_TO_ANOTHER_DEVICE, READER_SOFTWARE_UPDATE_FAILED, READER_SOFTWARE_UPDATE_FAILED_READER_ERROR, READER_SOFTWARE_UPDATE_FAILED_SERVER_ERROR, NFC_DISABLED, UNSUPPORTED_READER_VERSION, UNEXPECTED_SDK_ERROR, UNEXPECTED_READER_ERROR, ENCRYPTION_KEY_FAILURE, ENCRYPTION_KEY_STILL_INITIALIZING, DECLINED_BY_STRIPE_API, DECLINED_BY_READER, COMMAND_INVALID_ALLOW_REDISPLAY, NOT_CONNECTED_TO_INTERNET, REQUEST_TIMED_OUT, STRIPE_API_CONNECTION_ERROR, STRIPE_API_ERROR, STRIPE_API_RESPONSE_DECODING_ERROR, INTERNAL_NETWORK_ERROR, CONNECTION_TOKEN_PROVIDER_ERROR, SESSION_EXPIRED, UNSUPPORTED_MOBILE_DEVICE_CONFIGURATION, COMMAND_NOT_ALLOWED, AMOUNT_EXCEEDS_MAX_OFFLINE_AMOUNT, OFFLINE_PAYMENTS_DATABASE_TOO_LARGE, READER_CONNECTION_NOT_AVAILABLE_OFFLINE, READER_CONNECTION_OFFLINE_LOCATION_MISMATCH, READER_CONNECTION_OFFLINE_NEEDS_UPDATE, LOCATION_CONNECTION_NOT_AVAILABLE_OFFLINE, NO_LAST_SEEN_ACCOUNT, INVALID_OFFLINE_CURRENCY, REFUND_FAILED, CARD_SWIPE_NOT_AVAILABLE, INTERAC_NOT_SUPPORTED_OFFLINE, ONLINE_PIN_NOT_SUPPORTED_OFFLINE, MOBILE_WALLET_NOT_SUPPORTED_ON_SETUP_INTENTS, OFFLINE_AND_CARD_EXPIRED, OFFLINE_TRANSACTION_DECLINED, OFFLINE_COLLECT_AND_CONFIRM_MISMATCH, FORWARDING_TEST_MODE_PAYMENT_IN_LIVE_MODE, FORWARDING_LIVE_MODE_PAYMENT_IN_TEST_MODE, OFFLINE_PAYMENT_INTENT_NOT_FOUND, UPDATE_PAYMENT_INTENT_UNAVAILABLE_WHILE_OFFLINE, UPDATE_PAYMENT_INTENT_UNAVAILABLE_WHILE_OFFLINE_MODE_ENABLED, MISSING_EMV_DATA, CONNECTION_TOKEN_PROVIDER_ERROR_WHILE_FORWARDING, CONNECTION_TOKEN_PROVIDER_TIMED_OUT, ACCOUNT_ID_MISMATCH_WHILE_FORWARDING, OFFLINE_BEHAVIOR_FORCE_OFFLINE_WITH_FEATURE_DISABLED, NOT_CONNECTED_TO_INTERNET_AND_OFFLINE_BEHAVIOR_REQUIRE_ONLINE, TEST_CARD_IN_LIVE_MODE, COLLECT_INPUTS_APPLICATION_ERROR, COLLECT_INPUTS_TIMED_OUT, CANCELED_DUE_TO_INTEGRATION_ERROR, PRINTER_BUSY, PRINTER_PAPERJAM, PRINTER_OUT_OF_PAPER, PRINTER_COVER_OPEN, PRINTER_ABSENT, PRINTER_UNAVAILABLE, PRINTER_ERROR, COLLECT_INPUTS_UNSUPPORTED, READER_SETTINGS_ERROR, READER_COMMUNICATION_SSL_ERROR, ALLOW_REDISPLAY_INVALID, TAP_TO_PAY_UNSUPPORTED_PROCESSOR;
 }
 
 data class TipApi(

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/TerminalApi.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/TerminalApi.kt
@@ -58,7 +58,7 @@ interface TerminalPlatformApi {
         shouldPrintLogs: Boolean,
     )
 
-    fun onClearCachedCredentials()
+    fun onClearCachedCredentials(): ClearCachedCredentialsResultApi
 
     fun onGetConnectionStatus(): ConnectionStatusApi
 
@@ -233,8 +233,8 @@ interface TerminalPlatformApi {
                     result.success(null)
                 }
                 "clearCachedCredentials" -> {
-                    onClearCachedCredentials()
-                    result.success(null)
+                    val res = onClearCachedCredentials()
+                    result.success(res.serialize())
                 }
                 "getConnectionStatus" -> {
                     val res = onGetConnectionStatus()
@@ -550,6 +550,18 @@ data class AmountDetailsApi(
     fun serialize(): List<Any?> {
         return listOf(
             tip?.serialize(),
+        )
+    }
+}
+
+data class ClearCachedCredentialsResultApi(
+    val isSuccessful: Boolean,
+    val error: TerminalExceptionApi?,
+) {
+    fun serialize(): List<Any?> {
+        return listOf(
+            isSuccessful,
+            error?.serialize(),
         )
     }
 }

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/TerminalApi.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/TerminalApi.kt
@@ -1063,8 +1063,10 @@ data class InternetEasyConnectConfigurationApi(
             serialized: List<Any?>,
         ): InternetEasyConnectConfigurationApi {
             return InternetEasyConnectConfigurationApi(
-                connectionConfiguration = (serialized[0] as List<Any?>).let { InternetConnectionConfigurationApi.deserialize(it) },
-                discoveryConfiguration = (serialized[1] as List<Any?>).let { InternetDiscoveryConfigurationApi.deserialize(it) },
+                connectionConfiguration = (serialized[0] as List<Any?>).let { ConnectionConfigurationApi.deserialize(it) }
+                    as InternetConnectionConfigurationApi,
+                discoveryConfiguration = (serialized[1] as List<Any?>).let { DiscoveryConfigurationApi.deserialize(it) }
+                    as InternetDiscoveryConfigurationApi,
             )
         }
     }
@@ -1079,8 +1081,10 @@ data class AppsOnDevicesEasyConnectionConfigurationApi(
             serialized: List<Any?>,
         ): AppsOnDevicesEasyConnectionConfigurationApi {
             return AppsOnDevicesEasyConnectionConfigurationApi(
-                connectionConfiguration = (serialized[0] as List<Any?>).let { AppsOnDevicesConnectionConfigurationApi.deserialize(it) },
-                discoveryConfiguration = (serialized[1] as List<Any?>).let { AppsOnDevicesDiscoveryConfigurationApi.deserialize(it) },
+                connectionConfiguration = (serialized[0] as List<Any?>).let { ConnectionConfigurationApi.deserialize(it) }
+                    as AppsOnDevicesConnectionConfigurationApi,
+                discoveryConfiguration = (serialized[1] as List<Any?>).let { DiscoveryConfigurationApi.deserialize(it) }
+                    as AppsOnDevicesDiscoveryConfigurationApi,
             )
         }
     }
@@ -1095,8 +1099,10 @@ data class TapToPayEasyConnectConfigurationApi(
             serialized: List<Any?>,
         ): TapToPayEasyConnectConfigurationApi {
             return TapToPayEasyConnectConfigurationApi(
-                connectionConfiguration = (serialized[0] as List<Any?>).let { TapToPayConnectionConfigurationApi.deserialize(it) },
-                discoveryConfiguration = (serialized[1] as List<Any?>).let { TapToPayDiscoveryConfigurationApi.deserialize(it) },
+                connectionConfiguration = (serialized[0] as List<Any?>).let { ConnectionConfigurationApi.deserialize(it) }
+                    as TapToPayConnectionConfigurationApi,
+                discoveryConfiguration = (serialized[1] as List<Any?>).let { DiscoveryConfigurationApi.deserialize(it) }
+                    as TapToPayDiscoveryConfigurationApi,
             )
         }
     }

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/mappings/ConnectionCofiguration.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/mappings/ConnectionCofiguration.kt
@@ -1,6 +1,7 @@
 package mek.stripeterminal.mappings
 
 import com.stripe.stripeterminal.external.models.ConnectionConfiguration
+import mek.stripeterminal.api.AppsOnDevicesConnectionConfigurationApi
 import mek.stripeterminal.api.BluetoothConnectionConfigurationApi
 import mek.stripeterminal.api.ConnectionConfigurationApi
 import mek.stripeterminal.api.HandoffConnectionConfigurationApi
@@ -24,8 +25,11 @@ fun ConnectionConfigurationApi.toHost(readerDelegate: ReaderDelegatePlugin): Con
 //            shouldActivateWithExpandedLocation = shouldActivateWithExpandedLocation,
 //            shouldGenerateOfflineSessionToken = shouldGenerateOfflineSessionToken,
 //        )
-        is HandoffConnectionConfigurationApi -> ConnectionConfiguration.HandoffConnectionConfiguration(
-            handoffReaderListener = readerDelegate,
+        is AppsOnDevicesConnectionConfigurationApi -> ConnectionConfiguration.AppsOnDevicesConnectionConfiguration(
+            appsOnDevicesListener = readerDelegate,
+        )
+        is HandoffConnectionConfigurationApi -> ConnectionConfiguration.AppsOnDevicesConnectionConfiguration(
+            appsOnDevicesListener = readerDelegate,
         )
         is InternetConnectionConfigurationApi -> ConnectionConfiguration.InternetConnectionConfiguration(
             failIfInUse = failIfInUse,

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/mappings/DisconnectReasonMappings.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/mappings/DisconnectReasonMappings.kt
@@ -14,5 +14,7 @@ fun DisconnectReason.toApi(): DisconnectReasonApi {
         DisconnectReason.BLUETOOTH_DISABLED -> DisconnectReasonApi.BLUETOOTH_DISABLED
         DisconnectReason.USB_DISCONNECTED -> DisconnectReasonApi.USB_DISCONNECTED
         DisconnectReason.IDLE_POWER_DOWN -> DisconnectReasonApi.IDLE_POWER_DOWN
+        DisconnectReason.BLUETOOTH_PEER_REMOVED_PAIRING_INFORMATION ->
+            DisconnectReasonApi.BLUETOOTH_PEER_REMOVED_PAIRING_INFORMATION
     }
 }

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/mappings/EasyConnectConfigurationMappings.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/mappings/EasyConnectConfigurationMappings.kt
@@ -1,0 +1,78 @@
+package mek.stripeterminal.mappings
+
+import com.stripe.stripeterminal.external.models.DiscoveryConfiguration
+import com.stripe.stripeterminal.external.models.EasyConnectConfiguration
+import com.stripe.stripeterminal.external.models.EasyConnectConfiguration.AppsOnDevicesEasyConnectionConfiguration
+import com.stripe.stripeterminal.external.models.EasyConnectConfiguration.InternetEasyConnectConfiguration
+import com.stripe.stripeterminal.external.models.EasyConnectConfiguration.TapToPayEasyConnectConfiguration
+import com.stripe.stripeterminal.external.models.ConnectionConfiguration.AppsOnDevicesConnectionConfiguration
+import com.stripe.stripeterminal.external.models.ConnectionConfiguration.InternetConnectionConfiguration
+import com.stripe.stripeterminal.external.models.ConnectionConfiguration.TapToPayConnectionConfiguration
+import mek.stripeterminal.api.AppsOnDevicesEasyConnectionConfigurationApi
+import mek.stripeterminal.api.ConnectionConfigurationApi
+import mek.stripeterminal.api.EasyConnectConfigurationApi
+import mek.stripeterminal.api.InternetEasyConnectConfigurationApi
+import mek.stripeterminal.api.TapToPayEasyConnectConfigurationApi
+import mek.stripeterminal.plugin.ReaderDelegatePlugin
+
+fun EasyConnectConfigurationApi.toHost(readerDelegate: ReaderDelegatePlugin): EasyConnectConfiguration {
+    return when (this) {
+        is InternetEasyConnectConfigurationApi -> InternetEasyConnectConfiguration(
+            discoveryConfiguration = requireInternetDiscovery(discoveryConfiguration),
+            connectionConfiguration = requireInternetConnection(connectionConfiguration, readerDelegate)
+        )
+        is AppsOnDevicesEasyConnectionConfigurationApi -> AppsOnDevicesEasyConnectionConfiguration(
+            discoveryConfiguration = DiscoveryConfiguration.AppsOnDevicesDiscoveryConfiguration(),
+            connectionConfiguration = requireAppsOnDevicesConnection(connectionConfiguration, readerDelegate)
+        )
+        is TapToPayEasyConnectConfigurationApi -> TapToPayEasyConnectConfiguration(
+            discoveryConfiguration = requireTapToPayDiscovery(discoveryConfiguration),
+            connectionConfiguration = requireTapToPayConnection(connectionConfiguration, readerDelegate)
+        )
+    }
+}
+
+private fun requireInternetDiscovery(
+    discoveryConfiguration: mek.stripeterminal.api.DiscoveryConfigurationApi,
+): DiscoveryConfiguration.InternetDiscoveryConfiguration {
+    val host = discoveryConfiguration.toHost()
+        ?: throw IllegalArgumentException("Discovery method not supported")
+    return host as? DiscoveryConfiguration.InternetDiscoveryConfiguration
+        ?: throw IllegalArgumentException("Internet discovery configuration required")
+}
+
+private fun requireTapToPayDiscovery(
+    discoveryConfiguration: mek.stripeterminal.api.DiscoveryConfigurationApi,
+): DiscoveryConfiguration.TapToPayDiscoveryConfiguration {
+    val host = discoveryConfiguration.toHost()
+        ?: throw IllegalArgumentException("Discovery method not supported")
+    return host as? DiscoveryConfiguration.TapToPayDiscoveryConfiguration
+        ?: throw IllegalArgumentException("TapToPay discovery configuration required")
+}
+
+private fun requireInternetConnection(
+    connectionConfiguration: ConnectionConfigurationApi,
+    readerDelegate: ReaderDelegatePlugin,
+): InternetConnectionConfiguration {
+    val host = connectionConfiguration.toHost(readerDelegate)
+    return host as? InternetConnectionConfiguration
+        ?: throw IllegalArgumentException("Internet connection configuration required")
+}
+
+private fun requireAppsOnDevicesConnection(
+    connectionConfiguration: ConnectionConfigurationApi,
+    readerDelegate: ReaderDelegatePlugin,
+): AppsOnDevicesConnectionConfiguration {
+    val host = connectionConfiguration.toHost(readerDelegate)
+    return host as? AppsOnDevicesConnectionConfiguration
+        ?: throw IllegalArgumentException("AppsOnDevices connection configuration required")
+}
+
+private fun requireTapToPayConnection(
+    connectionConfiguration: ConnectionConfigurationApi,
+    readerDelegate: ReaderDelegatePlugin,
+): TapToPayConnectionConfiguration {
+    val host = connectionConfiguration.toHost(readerDelegate)
+    return host as? TapToPayConnectionConfiguration
+        ?: throw IllegalArgumentException("TapToPay connection configuration required")
+}

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/mappings/ExceptionMappings.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/mappings/ExceptionMappings.kt
@@ -115,6 +115,7 @@ private fun TerminalErrorCode.toApiCode(): TerminalExceptionCodeApi? {
         TerminalErrorCode.READER_SETTINGS_ERROR -> TerminalExceptionCodeApi.READER_SETTINGS_ERROR
         TerminalErrorCode.READER_MISSING_ENCRYPTION_KEYS -> TerminalExceptionCodeApi.READER_MISSING_ENCRYPTION_KEYS
         TerminalErrorCode.INVALID_SURCHARGE_PARAMETER -> TerminalExceptionCodeApi.INVALID_SURCHARGE_PARAMETER
+        TerminalErrorCode.INVALID_MOTO_CONFIGURATION -> TerminalExceptionCodeApi.INVALID_PARAMETER
         TerminalErrorCode.READER_COMMUNICATION_SSL_ERROR -> TerminalExceptionCodeApi.READER_COMMUNICATION_SSL_ERROR
         TerminalErrorCode.TAP_TO_PAY_INSECURE_ENVIRONMENT -> TerminalExceptionCodeApi.TAP_TO_PAY_INSECURE_ENVIRONMENT
         TerminalErrorCode.GENERIC_READER_ERROR -> TerminalExceptionCodeApi.UNEXPECTED_READER_ERROR

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/mappings/PaymentIntentMappings.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/mappings/PaymentIntentMappings.kt
@@ -2,6 +2,7 @@ package mek.stripeterminal.mappings
 
 import com.stripe.stripeterminal.external.models.AmountDetails
 import com.stripe.stripeterminal.external.models.CaptureMethod
+import com.stripe.stripeterminal.external.models.ConfirmPaymentIntentConfiguration
 import com.stripe.stripeterminal.external.models.PaymentIntent
 import com.stripe.stripeterminal.external.models.PaymentIntentParameters
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus
@@ -11,6 +12,7 @@ import com.stripe.stripeterminal.external.models.PaymentStatus
 import mek.stripeterminal.api.AmountDetailsApi
 import mek.stripeterminal.api.CaptureMethodApi
 import mek.stripeterminal.api.ConfirmationMethodApi
+import mek.stripeterminal.api.ConfirmPaymentIntentConfigurationApi
 import mek.stripeterminal.api.PaymentIntentApi
 import mek.stripeterminal.api.PaymentIntentParametersApi
 import mek.stripeterminal.api.PaymentIntentStatusApi
@@ -134,6 +136,12 @@ fun PaymentMethodOptionsParametersApi.toHost(): PaymentMethodOptionsParameters {
     return PaymentMethodOptionsParameters.Builder()
         .setCardPresentParameters(cardPresentParameters.toHost())
         .build()
+}
+
+fun ConfirmPaymentIntentConfigurationApi.toHost(): ConfirmPaymentIntentConfiguration {
+    val builder = ConfirmPaymentIntentConfiguration.Builder()
+    returnUrl?.let { builder.setReturnUrl(it) }
+    return builder.build()
 }
 
 // EXTRA

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/mappings/ReaderMappings.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/mappings/ReaderMappings.kt
@@ -7,6 +7,7 @@ import com.stripe.stripeterminal.external.models.CartLineItem
 import com.stripe.stripeterminal.external.models.ConnectionStatus
 import com.stripe.stripeterminal.external.models.DeviceType
 import com.stripe.stripeterminal.external.models.DiscoveryConfiguration
+import com.stripe.stripeterminal.external.models.DiscoveryFilter
 import com.stripe.stripeterminal.external.models.Location
 import com.stripe.stripeterminal.external.models.LocationStatus
 import com.stripe.stripeterminal.external.models.Reader
@@ -16,11 +17,15 @@ import com.stripe.stripeterminal.external.models.ReaderInputOptions
 import com.stripe.stripeterminal.external.models.ReaderSoftwareUpdate
 import mek.stripeterminal.api.AddressApi
 import mek.stripeterminal.api.BatteryStatusApi
+import mek.stripeterminal.api.AppsOnDevicesDiscoveryConfigurationApi
 import mek.stripeterminal.api.BluetoothDiscoveryConfigurationApi
 import mek.stripeterminal.api.BluetoothProximityDiscoveryConfigurationApi
 import mek.stripeterminal.api.CartApi
 import mek.stripeterminal.api.CartLineItemApi
 import mek.stripeterminal.api.ConnectionStatusApi
+import mek.stripeterminal.api.DiscoveryFilterApi
+import mek.stripeterminal.api.DiscoveryFilterByReaderIdApi
+import mek.stripeterminal.api.DiscoveryFilterBySerialNumberApi
 import mek.stripeterminal.api.DeviceTypeApi
 import mek.stripeterminal.api.DiscoveryConfigurationApi
 import mek.stripeterminal.api.HandoffDiscoveryConfigurationApi
@@ -71,7 +76,6 @@ fun DeviceType.toApi(): DeviceTypeApi? {
         DeviceType.CHIPPER_2X -> DeviceTypeApi.CHIPPER2_X
         DeviceType.STRIPE_M2 -> DeviceTypeApi.STRIPE_M2
         DeviceType.TAP_TO_PAY_DEVICE -> DeviceTypeApi.TAP_TO_PAY
-        DeviceType.VERIFONE_P400 -> DeviceTypeApi.VERIFONE_P400
         DeviceType.WISECUBE -> DeviceTypeApi.WISE_CUBE
         DeviceType.WISEPAD_3 -> DeviceTypeApi.WISE_PAD3
         DeviceType.WISEPAD_3S -> DeviceTypeApi.WISE_PAD3S
@@ -82,13 +86,20 @@ fun DeviceType.toApi(): DeviceTypeApi? {
         DeviceType.STRIPE_S700_DEVKIT -> DeviceTypeApi.STRIPE_S700_DEVKIT
         DeviceType.STRIPE_S710 -> DeviceTypeApi.STRIPE_S710
         DeviceType.STRIPE_S710_DEVKIT -> DeviceTypeApi.STRIPE_S710_DEVKIT
+        DeviceType.STRIPE_T600 -> DeviceTypeApi.STRIPE_T600
+        DeviceType.STRIPE_T600_DEVKIT -> DeviceTypeApi.STRIPE_T600_DEVKIT
+        DeviceType.STRIPE_T610 -> DeviceTypeApi.STRIPE_T610
+        DeviceType.STRIPE_T610_DEVKIT -> DeviceTypeApi.STRIPE_T610_DEVKIT
         DeviceType.VERIFONE_V660P -> DeviceTypeApi.VERIFONE_V660P
+        DeviceType.VERIFONE_V660PA -> DeviceTypeApi.VERIFONE_V660PA
         DeviceType.VERIFONE_M425 -> DeviceTypeApi.VERIFONE_M425
         DeviceType.VERIFONE_M450 -> DeviceTypeApi.VERIFONE_M450
         DeviceType.VERIFONE_P630 -> DeviceTypeApi.VERIFONE_P630
         DeviceType.VERIFONE_UX700 -> DeviceTypeApi.VERIFONE_UX700
         DeviceType.VERIFONE_V660P_DEVKIT -> DeviceTypeApi.VERIFONE_V660P_DEVKIT
         DeviceType.VERIFONE_UX700_DEVKIT -> DeviceTypeApi.VERIFONE_UX700_DEVKIT
+        DeviceType.VERIFONE_VM100 -> DeviceTypeApi.VERIFONE_VM100
+        DeviceType.VERIFONE_VP100 -> DeviceTypeApi.VERIFONE_VP100
         DeviceType.UNKNOWN -> null
     }
 }
@@ -208,12 +219,14 @@ fun DiscoveryConfigurationApi.toHost(): DiscoveryConfiguration? {
                 timeout = timeout?.let { microsecondsToSeconds(it) } ?: 0
             )
         is BluetoothProximityDiscoveryConfigurationApi -> null
-        is HandoffDiscoveryConfigurationApi -> DiscoveryConfiguration.HandoffDiscoveryConfiguration()
+        is AppsOnDevicesDiscoveryConfigurationApi -> DiscoveryConfiguration.AppsOnDevicesDiscoveryConfiguration()
+        is HandoffDiscoveryConfigurationApi -> DiscoveryConfiguration.AppsOnDevicesDiscoveryConfiguration()
         is InternetDiscoveryConfigurationApi ->
             DiscoveryConfiguration.InternetDiscoveryConfiguration(
                 isSimulated = isSimulated,
                 location = locationId,
-                timeout = timeout?.let { microsecondsToSeconds(it) } ?: 0
+                timeout = timeout?.let { microsecondsToSeconds(it) } ?: 0,
+                discoveryFilter = discoveryFilter.toHost()
             )
         is TapToPayDiscoveryConfigurationApi ->
             DiscoveryConfiguration.TapToPayDiscoveryConfiguration(
@@ -227,13 +240,21 @@ fun DiscoveryConfigurationApi.toHost(): DiscoveryConfiguration? {
     }
 }
 
+fun DiscoveryFilterApi?.toHost(): DiscoveryFilter {
+    return when (this) {
+        is DiscoveryFilterByReaderIdApi -> DiscoveryFilter.ByReaderId(readerId)
+        is DiscoveryFilterBySerialNumberApi -> DiscoveryFilter.BySerial(serialNumber)
+        null -> DiscoveryFilter.None
+        else -> DiscoveryFilter.None
+    }
+}
+
 fun DeviceTypeApi.toHost(): DeviceType? {
     return when (this) {
         DeviceTypeApi.CHIPPER1_X -> DeviceType.CHIPPER_1X
         DeviceTypeApi.CHIPPER2_X -> DeviceType.CHIPPER_2X
         DeviceTypeApi.STRIPE_M2 -> DeviceType.STRIPE_M2
         DeviceTypeApi.TAP_TO_PAY -> DeviceType.TAP_TO_PAY_DEVICE
-        DeviceTypeApi.VERIFONE_P400 -> DeviceType.VERIFONE_P400
         DeviceTypeApi.WISE_CUBE -> DeviceType.WISECUBE
         DeviceTypeApi.WISE_PAD3 -> DeviceType.WISEPAD_3
         DeviceTypeApi.WISE_POS_E -> DeviceType.WISEPOS_E
@@ -244,13 +265,21 @@ fun DeviceTypeApi.toHost(): DeviceType? {
         DeviceTypeApi.STRIPE_S700_DEVKIT -> DeviceType.STRIPE_S700_DEVKIT
         DeviceTypeApi.STRIPE_S710 -> DeviceType.STRIPE_S710
         DeviceTypeApi.STRIPE_S710_DEVKIT -> DeviceType.STRIPE_S710_DEVKIT
+        DeviceTypeApi.STRIPE_T600 -> DeviceType.STRIPE_T600
+        DeviceTypeApi.STRIPE_T600_DEVKIT -> DeviceType.STRIPE_T600_DEVKIT
+        DeviceTypeApi.STRIPE_T610 -> DeviceType.STRIPE_T610
+        DeviceTypeApi.STRIPE_T610_DEVKIT -> DeviceType.STRIPE_T610_DEVKIT
         DeviceTypeApi.VERIFONE_V660P -> DeviceType.VERIFONE_V660P
+        DeviceTypeApi.VERIFONE_V660PA -> DeviceType.VERIFONE_V660PA
         DeviceTypeApi.VERIFONE_M425 -> DeviceType.VERIFONE_M425
         DeviceTypeApi.VERIFONE_M450 -> DeviceType.VERIFONE_M450
         DeviceTypeApi.VERIFONE_P630 -> DeviceType.VERIFONE_P630
         DeviceTypeApi.VERIFONE_UX700 -> DeviceType.VERIFONE_UX700
         DeviceTypeApi.VERIFONE_V660P_DEVKIT -> DeviceType.VERIFONE_V660P_DEVKIT
         DeviceTypeApi.VERIFONE_UX700_DEVKIT -> DeviceType.VERIFONE_UX700_DEVKIT
+        DeviceTypeApi.VERIFONE_VM100 -> DeviceType.VERIFONE_VM100
+        DeviceTypeApi.VERIFONE_VP100 -> DeviceType.VERIFONE_VP100
+        DeviceTypeApi.VERIFONE_P400 -> null
     }
 }
 
@@ -281,5 +310,6 @@ fun ConnectionStatus.toApi(): ConnectionStatusApi {
         ConnectionStatus.CONNECTING -> ConnectionStatusApi.CONNECTING
         ConnectionStatus.CONNECTED -> ConnectionStatusApi.CONNECTED
         ConnectionStatus.DISCOVERING -> ConnectionStatusApi.DISCOVERING
+        ConnectionStatus.RECONNECTING -> ConnectionStatusApi.RECONNECTING
     }
 }

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/mappings/TapToPayUXConfigurationMappings.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/mappings/TapToPayUXConfigurationMappings.kt
@@ -5,7 +5,6 @@ import com.stripe.stripeterminal.external.models.TapToPayUxConfiguration
 import mek.stripeterminal.api.TapToPayUxConfigurationColorSchemeApi
 import mek.stripeterminal.api.TapToPayUxConfigurationTapZoneApi
 import mek.stripeterminal.api.TapToPayUxConfigurationTapZoneIndicatorApi
-import mek.stripeterminal.api.TapToPayUxConfigurationTapZonePositionApi
 import mek.stripeterminal.api.TapToPayUxConfigurationDarkModeApi
 
 
@@ -18,23 +17,29 @@ fun TapToPayUxConfigurationApi.toHost(): TapToPayUxConfiguration {
 }
 
 fun TapToPayUxConfigurationTapZoneApi.toHost(): TapToPayUxConfiguration.TapZone {
-    val builder = TapToPayUxConfiguration.TapZone.Manual.Builder()
-    if (indicator != null) builder.indicator(indicator.toHost())
-    if (position != null) builder.position(position.toHost())
-    return builder.build()
-}
-
-fun TapToPayUxConfigurationTapZoneIndicatorApi.toHost(): TapToPayUxConfiguration.TapZoneIndicator {
-    return when (this) {
-        TapToPayUxConfigurationTapZoneIndicatorApi.ABOVE -> TapToPayUxConfiguration.TapZoneIndicator.ABOVE
-        TapToPayUxConfigurationTapZoneIndicatorApi.BELOW -> TapToPayUxConfiguration.TapZoneIndicator.BELOW
-        TapToPayUxConfigurationTapZoneIndicatorApi.FRONT -> TapToPayUxConfiguration.TapZoneIndicator.FRONT
-        TapToPayUxConfigurationTapZoneIndicatorApi.BEHIND -> TapToPayUxConfiguration.TapZoneIndicator.BEHIND
+    val xBias = position?.xBias?.toFloat()
+    val yBias = position?.yBias?.toFloat()
+    return when (indicator) {
+        TapToPayUxConfigurationTapZoneIndicatorApi.LEFT ->
+            if (yBias != null) TapToPayUxConfiguration.TapZone.Left(yBias)
+            else TapToPayUxConfiguration.TapZone.Left()
+        TapToPayUxConfigurationTapZoneIndicatorApi.RIGHT ->
+            if (yBias != null) TapToPayUxConfiguration.TapZone.Right(yBias)
+            else TapToPayUxConfiguration.TapZone.Right()
+        TapToPayUxConfigurationTapZoneIndicatorApi.ABOVE ->
+            if (xBias != null) TapToPayUxConfiguration.TapZone.Above(xBias)
+            else TapToPayUxConfiguration.TapZone.Above()
+        TapToPayUxConfigurationTapZoneIndicatorApi.BELOW ->
+            if (xBias != null) TapToPayUxConfiguration.TapZone.Below(xBias)
+            else TapToPayUxConfiguration.TapZone.Below()
+        TapToPayUxConfigurationTapZoneIndicatorApi.FRONT ->
+            if (xBias != null && yBias != null) TapToPayUxConfiguration.TapZone.Front(xBias, yBias)
+            else TapToPayUxConfiguration.TapZone.Front()
+        TapToPayUxConfigurationTapZoneIndicatorApi.BEHIND ->
+            if (xBias != null && yBias != null) TapToPayUxConfiguration.TapZone.Behind(xBias, yBias)
+            else TapToPayUxConfiguration.TapZone.Behind()
+        null -> TapToPayUxConfiguration.TapZone.Default
     }
-}
-
-fun TapToPayUxConfigurationTapZonePositionApi.toHost(): TapToPayUxConfiguration.TapZonePosition {
-    return TapToPayUxConfiguration.TapZonePosition.Manual(xBias.toFloat(), yBias.toFloat());
 }
 
 fun TapToPayUxConfigurationColorSchemeApi.toHost(): TapToPayUxConfiguration.ColorScheme {

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/plugin/ReaderDelegatePlugin.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/plugin/ReaderDelegatePlugin.kt
@@ -1,7 +1,7 @@
 package mek.stripeterminal.plugin
 
 import com.stripe.stripeterminal.external.callable.Cancelable
-import com.stripe.stripeterminal.external.callable.HandoffReaderListener
+import com.stripe.stripeterminal.external.callable.AppsOnDevicesListener
 import com.stripe.stripeterminal.external.callable.InternetReaderListener
 import com.stripe.stripeterminal.external.callable.MobileReaderListener
 import com.stripe.stripeterminal.external.callable.TapToPayReaderListener
@@ -19,7 +19,7 @@ import mek.stripeterminal.runOnMainThread
 import com.stripe.stripeterminal.external.callable.Callback
 
 class ReaderDelegatePlugin(private val _handlers: TerminalHandlersApi) :
-    MobileReaderListener, HandoffReaderListener, InternetReaderListener, TapToPayReaderListener {
+    MobileReaderListener, AppsOnDevicesListener, InternetReaderListener, TapToPayReaderListener {
     private var cancelableReconnect: Cancelable? = null
     private var cancelableUpdate: Cancelable? = null
 

--- a/stripe_terminal/example/lib/models/discovery_method.dart
+++ b/stripe_terminal/example/lib/models/discovery_method.dart
@@ -8,8 +8,8 @@ enum DiscoveryMethod {
   /// [BluetoothProximityDiscoveryConfiguration]
   bluetoothProximity(canSimulate: true),
 
-  /// [HandoffDiscoveryConfiguration]
-  handOff(),
+  /// [AppsOnDevicesDiscoveryConfiguration]
+  appsOnDevices(),
 
   /// [InternetDiscoveryConfiguration]
   internet(canSimulate: true),

--- a/stripe_terminal/example/lib/screens/configuration_screen.dart
+++ b/stripe_terminal/example/lib/screens/configuration_screen.dart
@@ -60,7 +60,7 @@ class _PaymentsScreenState extends ConsumerState<ConfigurationScreen> with State
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         DropdownButtonFormField<TapToPayUxConfigurationTapZoneIndicator>(
-          value: _indicator,
+          initialValue: _indicator,
           decoration: const InputDecoration(labelText: 'Tap Zone Indicator'),
           items: TapToPayUxConfigurationTapZoneIndicator.values
               .map((e) => DropdownMenuItem(value: e, child: Text(e.toString().split('.').last)))
@@ -103,7 +103,7 @@ class _PaymentsScreenState extends ConsumerState<ConfigurationScreen> with State
           onColorChanged: (color) => setState(() => _errorColor = color),
         ),
         DropdownButtonFormField<TapToPayUxConfigurationDarkMode>(
-          value: _darkMode,
+          initialValue: _darkMode,
           decoration: const InputDecoration(labelText: 'Dark Mode'),
           items: TapToPayUxConfigurationDarkMode.values
               .map((e) => DropdownMenuItem(value: e, child: Text(e.toString().split('.').last)))

--- a/stripe_terminal/example/lib/screens/more_screen.dart
+++ b/stripe_terminal/example/lib/screens/more_screen.dart
@@ -34,7 +34,12 @@ class _MoreScreenState extends ConsumerState<MoreScreen> with StateTools {
         children: [
           FilledButton.tonal(
             onPressed: !isMutating && connectionStatus == ConnectionStatus.notConnected
-                ? () => mutate(Terminal.instance.clearCachedCredentials)
+                ? () => mutate(() async {
+                      final result = await Terminal.instance.clearCachedCredentials();
+                      if (!result.isSuccessful) {
+                        throw result.error ?? Exception('Clear cached credentials failed.');
+                      }
+                    })
                 : null,
             child: const Text('Clear cached credentials'),
           ),

--- a/stripe_terminal/example/lib/screens/readers_screen.dart
+++ b/stripe_terminal/example/lib/screens/readers_screen.dart
@@ -64,7 +64,7 @@ class _ReadersScreenState extends ConsumerState<ReadersScreen> with StateTools {
       DiscoveryMethod.bluetoothProximity => BluetoothProximityDiscoveryConfiguration(
           isSimulated: _isSimulated,
         ),
-      DiscoveryMethod.handOff => const HandoffDiscoveryConfiguration(),
+      DiscoveryMethod.appsOnDevices => const AppsOnDevicesDiscoveryConfiguration(),
       DiscoveryMethod.internet => InternetDiscoveryConfiguration(
           isSimulated: _isSimulated,
         ),
@@ -115,8 +115,8 @@ class _ReadersScreenState extends ConsumerState<ReadersScreen> with StateTools {
         DiscoveryMethod.internet => InternetConnectionConfiguration(
             readerDelegate: LoggingInternetReaderDelegate(showSnackBar),
           ),
-        DiscoveryMethod.handOff => HandoffConnectionConfiguration(
-            readerDelegate: LoggingHandoffReaderDelegate(showSnackBar),
+        DiscoveryMethod.appsOnDevices => AppsOnDevicesConnectionConfiguration(
+            readerDelegate: LoggingAppsOnDevicesReaderDelegate(showSnackBar),
           ),
         DiscoveryMethod.usb => UsbConnectionConfiguration(
             locationId: getLocationId(),

--- a/stripe_terminal/example/lib/screens/readers_screen.dart
+++ b/stripe_terminal/example/lib/screens/readers_screen.dart
@@ -164,7 +164,7 @@ class _ReadersScreenState extends ConsumerState<ReadersScreen> with StateTools {
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
               child: DropdownButtonFormField<DiscoveryMethod>(
-                value: _discoveryMethod,
+                initialValue: _discoveryMethod,
                 onChanged: !isMutating && connectionStatus == ConnectionStatus.notConnected
                     ? _changeDiscoveryMethod
                     : null,

--- a/stripe_terminal/example/lib/utils/reader_delegates.dart
+++ b/stripe_terminal/example/lib/utils/reader_delegates.dart
@@ -85,12 +85,12 @@ class LoggingMobileReaderDelegate extends MobileReaderDelegate
       onLog('onReportAvailableUpdate: ${update.version}');
 }
 
-class LoggingHandoffReaderDelegate extends HandoffReaderDelegate
+class LoggingAppsOnDevicesReaderDelegate extends AppsOnDevicesReaderDelegate
     with _LoggingReaderDelegate, _LoggingReaderDisconnectDelegate {
   @override
   final LogListener onLog;
 
-  LoggingHandoffReaderDelegate(this.onLog);
+  LoggingAppsOnDevicesReaderDelegate(this.onLog);
 }
 
 class LoggingInternetReaderDelegate extends InternetReaderDelegate

--- a/stripe_terminal/lib/mek_stripe_terminal.dart
+++ b/stripe_terminal/lib/mek_stripe_terminal.dart
@@ -9,6 +9,8 @@ export 'src/models/charge.dart';
 export 'src/models/connection_configuration.dart';
 export 'src/models/disconnect_reason.dart';
 export 'src/models/discovery_configuration.dart';
+export 'src/models/discovery_filter.dart';
+export 'src/models/easy_connect_configuration.dart';
 export 'src/models/location.dart';
 export 'src/models/payment.dart';
 export 'src/models/payment_intent.dart';

--- a/stripe_terminal/lib/mek_stripe_terminal.dart
+++ b/stripe_terminal/lib/mek_stripe_terminal.dart
@@ -6,6 +6,7 @@ export 'src/cancellable_future.dart';
 export 'src/models/card.dart';
 export 'src/models/cart.dart';
 export 'src/models/charge.dart';
+export 'src/models/clear_cached_credentials_result.dart';
 export 'src/models/connection_configuration.dart';
 export 'src/models/disconnect_reason.dart';
 export 'src/models/discovery_configuration.dart';

--- a/stripe_terminal/lib/src/models/clear_cached_credentials_result.dart
+++ b/stripe_terminal/lib/src/models/clear_cached_credentials_result.dart
@@ -1,0 +1,13 @@
+import 'package:mek_stripe_terminal/src/terminal_exception.dart';
+import 'package:one_for_all/one_for_all.dart';
+
+@SerializableClass(hostToFlutter: true)
+class ClearCachedCredentialsResult {
+  final bool isSuccessful;
+  final TerminalException? error;
+
+  const ClearCachedCredentialsResult({
+    required this.isSuccessful,
+    required this.error,
+  });
+}

--- a/stripe_terminal/lib/src/models/connection_configuration.dart
+++ b/stripe_terminal/lib/src/models/connection_configuration.dart
@@ -33,13 +33,17 @@ class AppsOnDevicesConnectionConfiguration extends ConnectionConfiguration {
 
 @Deprecated('Use AppsOnDevicesConnectionConfiguration')
 class HandoffConnectionConfiguration extends AppsOnDevicesConnectionConfiguration {
-  @override
   @SerializableParam.ignore()
-  final HandoffReaderDelegate? readerDelegate;
+  final HandoffReaderDelegate? _handoffReaderDelegate;
 
+  @override
+  HandoffReaderDelegate? get readerDelegate => _handoffReaderDelegate;
+
+  @Deprecated('Use AppsOnDevicesConnectionConfiguration')
   const HandoffConnectionConfiguration({
-    required this.readerDelegate,
-  }) : super(readerDelegate: readerDelegate);
+    required HandoffReaderDelegate? readerDelegate,
+  })  : _handoffReaderDelegate = readerDelegate,
+        super(readerDelegate: readerDelegate);
 }
 
 class InternetConnectionConfiguration extends ConnectionConfiguration {

--- a/stripe_terminal/lib/src/models/connection_configuration.dart
+++ b/stripe_terminal/lib/src/models/connection_configuration.dart
@@ -21,14 +21,25 @@ class BluetoothConnectionConfiguration extends ConnectionConfiguration {
   });
 }
 
-class HandoffConnectionConfiguration extends ConnectionConfiguration {
+class AppsOnDevicesConnectionConfiguration extends ConnectionConfiguration {
+  @override
+  @SerializableParam.ignore()
+  final AppsOnDevicesReaderDelegate? readerDelegate;
+
+  const AppsOnDevicesConnectionConfiguration({
+    required this.readerDelegate,
+  });
+}
+
+@Deprecated('Use AppsOnDevicesConnectionConfiguration')
+class HandoffConnectionConfiguration extends AppsOnDevicesConnectionConfiguration {
   @override
   @SerializableParam.ignore()
   final HandoffReaderDelegate? readerDelegate;
 
   const HandoffConnectionConfiguration({
     required this.readerDelegate,
-  });
+  }) : super(readerDelegate: readerDelegate);
 }
 
 class InternetConnectionConfiguration extends ConnectionConfiguration {

--- a/stripe_terminal/lib/src/models/disconnect_reason.dart
+++ b/stripe_terminal/lib/src/models/disconnect_reason.dart
@@ -34,4 +34,7 @@ enum DisconnectReason {
   /// The mobile reader’s Bluetooth signal has been lost, either because it is out of range, or due
   /// to wireless interference.
   bluetoothSignalLost,
+
+  /// The mobile reader's Bluetooth pairing has been cleared. Forget the reader in system settings.
+  bluetoothPeerRemovedPairingInformation,
 }

--- a/stripe_terminal/lib/src/models/discovery_configuration.dart
+++ b/stripe_terminal/lib/src/models/discovery_configuration.dart
@@ -1,10 +1,12 @@
+import 'package:mek_stripe_terminal/src/models/discovery_filter.dart';
+
 /// Protocol for classes to conform to that apply configuration options for discovering readers.
 ///
 /// You should not implement this protocol yourself; instead, use one of the following:
 ///
 /// - [BluetoothDiscoveryConfiguration]
 /// - [BluetoothProximityDiscoveryConfiguration]
-/// - [HandoffDiscoveryConfiguration]
+/// - [AppsOnDevicesDiscoveryConfiguration]
 /// - [InternetDiscoveryConfiguration]
 /// - [LocalMobileDiscoveryConfiguration]
 /// - [UsbDiscoveryConfiguration]
@@ -59,7 +61,13 @@ class BluetoothProximityDiscoveryConfiguration extends DiscoveryConfiguration {
 }
 
 /// ONLY ON ANDROID
-class HandoffDiscoveryConfiguration extends DiscoveryConfiguration {
+class AppsOnDevicesDiscoveryConfiguration extends DiscoveryConfiguration {
+  const AppsOnDevicesDiscoveryConfiguration();
+}
+
+/// ONLY ON ANDROID
+@Deprecated('Use AppsOnDevicesDiscoveryConfiguration')
+class HandoffDiscoveryConfiguration extends AppsOnDevicesDiscoveryConfiguration {
   const HandoffDiscoveryConfiguration();
 }
 
@@ -77,11 +85,13 @@ class InternetDiscoveryConfiguration extends DiscoveryConfiguration {
   final bool isSimulated;
   final String? locationId;
   final Duration? timeout;
+  final DiscoveryFilter? discoveryFilter;
 
   const InternetDiscoveryConfiguration({
     this.isSimulated = false,
     this.locationId,
     this.timeout,
+    this.discoveryFilter,
   });
 }
 

--- a/stripe_terminal/lib/src/models/discovery_configuration.dart
+++ b/stripe_terminal/lib/src/models/discovery_configuration.dart
@@ -68,6 +68,7 @@ class AppsOnDevicesDiscoveryConfiguration extends DiscoveryConfiguration {
 /// ONLY ON ANDROID
 @Deprecated('Use AppsOnDevicesDiscoveryConfiguration')
 class HandoffDiscoveryConfiguration extends AppsOnDevicesDiscoveryConfiguration {
+  @Deprecated('Use AppsOnDevicesDiscoveryConfiguration')
   const HandoffDiscoveryConfiguration();
 }
 

--- a/stripe_terminal/lib/src/models/discovery_filter.dart
+++ b/stripe_terminal/lib/src/models/discovery_filter.dart
@@ -1,0 +1,21 @@
+import 'package:one_for_all/one_for_all.dart';
+
+/// Filters for Internet reader discovery.
+@SerializableClass(flutterToHost: true)
+sealed class DiscoveryFilter {
+  const DiscoveryFilter();
+}
+
+/// Filters internet discovery by reader ID.
+class DiscoveryFilterByReaderId extends DiscoveryFilter {
+  final String readerId;
+
+  const DiscoveryFilterByReaderId(this.readerId);
+}
+
+/// Filters internet discovery by reader serial number.
+class DiscoveryFilterBySerialNumber extends DiscoveryFilter {
+  final String serialNumber;
+
+  const DiscoveryFilterBySerialNumber(this.serialNumber);
+}

--- a/stripe_terminal/lib/src/models/easy_connect_configuration.dart
+++ b/stripe_terminal/lib/src/models/easy_connect_configuration.dart
@@ -1,0 +1,37 @@
+import 'package:mek_stripe_terminal/src/models/connection_configuration.dart';
+import 'package:mek_stripe_terminal/src/models/discovery_configuration.dart';
+
+/// Configuration for the EasyConnect flow, which discovers and connects to a reader in one step.
+sealed class EasyConnectConfiguration {
+  const EasyConnectConfiguration();
+}
+
+class InternetEasyConnectConfiguration extends EasyConnectConfiguration {
+  final InternetDiscoveryConfiguration discoveryConfiguration;
+  final InternetConnectionConfiguration connectionConfiguration;
+
+  const InternetEasyConnectConfiguration({
+    required this.discoveryConfiguration,
+    required this.connectionConfiguration,
+  });
+}
+
+class AppsOnDevicesEasyConnectionConfiguration extends EasyConnectConfiguration {
+  final AppsOnDevicesDiscoveryConfiguration discoveryConfiguration;
+  final AppsOnDevicesConnectionConfiguration connectionConfiguration;
+
+  const AppsOnDevicesEasyConnectionConfiguration({
+    required this.discoveryConfiguration,
+    required this.connectionConfiguration,
+  });
+}
+
+class TapToPayEasyConnectConfiguration extends EasyConnectConfiguration {
+  final TapToPayDiscoveryConfiguration discoveryConfiguration;
+  final TapToPayConnectionConfiguration connectionConfiguration;
+
+  const TapToPayEasyConnectConfiguration({
+    required this.discoveryConfiguration,
+    required this.connectionConfiguration,
+  });
+}

--- a/stripe_terminal/lib/src/models/payment_intent.dart
+++ b/stripe_terminal/lib/src/models/payment_intent.dart
@@ -43,7 +43,8 @@ class PaymentIntent with _$PaymentIntent {
   /// Charges that were created by this PaymentIntent, if any.
   final List<Charge> charges;
 
-  /// The payment method to be used in this PaymentIntent. Only valid in the intent returned during collectPaymentMethod when using the updatePaymentIntent option in the SCPCollectConfiguration.
+  /// The payment method to be used in this PaymentIntent. Only valid in the intent returned during
+  /// processPaymentIntent when updatePaymentIntent is enabled.
   final PaymentMethod? paymentMethod;
 
   /// ID of the payment method used in this PaymentIntent.
@@ -54,9 +55,9 @@ class PaymentIntent with _$PaymentIntent {
 
   /// Indicates how much the user intends to tip in addition to the amount by at confirmation time.
   /// This is only non-null in the [PaymentIntent] instance returned during collect when using
-  /// updatePaymentIntent set to true in the CollectConfiguration.
+  /// updatePaymentIntent set to true in processPaymentIntent.
   ///
-  /// After [Terminal.confirmPaymentIntent] the amount will have this tip amount added
+  /// After [Terminal.processPaymentIntent] the amount will have this tip amount added
   /// to it and the [amountDetails] will contain the breakdown of how much of the amount was a tip.
   final double? amountTip;
 
@@ -173,10 +174,10 @@ enum PaymentIntentStatus {
   /// Next step: capture the [PaymentIntent] on your backend via the Stripe API.
   requiresCapture,
 
-  /// Next step: confirm the payment by calling [Terminal.confirmPaymentIntent].
+  /// Next step: process the payment by calling [Terminal.processPaymentIntent].
   requiresConfirmation,
 
-  /// Next step: collect a payment method by calling [Terminal.collectPaymentMethod].
+  /// Next step: process the payment by calling [Terminal.processPaymentIntent].
   requiresPaymentMethod,
 
   /// Next step: the payment requires additional actions, such as authenticating with 3D Secure.
@@ -335,5 +336,16 @@ class PaymentMethodOptionsParameters with _$PaymentMethodOptionsParameters {
 
   const PaymentMethodOptionsParameters({
     required this.cardPresentParameters,
+  });
+}
+
+/// Configuration for confirming a payment intent.
+@immutable
+class ConfirmPaymentIntentConfiguration {
+  /// The URL to redirect the customer back to after authentication.
+  final String? returnUrl;
+
+  const ConfirmPaymentIntentConfiguration({
+    this.returnUrl,
   });
 }

--- a/stripe_terminal/lib/src/models/reader.dart
+++ b/stripe_terminal/lib/src/models/reader.dart
@@ -63,8 +63,6 @@ class Reader with _$Reader {
 
   final Location? location;
 
-  // TODO: Add location field
-
   /// The reader’s serial number.
   final String serialNumber;
 

--- a/stripe_terminal/lib/src/models/reader.dart
+++ b/stripe_terminal/lib/src/models/reader.dart
@@ -16,6 +16,9 @@ enum ConnectionStatus {
   connecting,
 
   discovering,
+
+  /// The SDK is reconnecting to a reader.
+  reconnecting,
 }
 
 /// Information about a card reader that has been discovered by or connected to the SDK.
@@ -170,8 +173,23 @@ enum DeviceType {
   /// Stripe Reader S710 DevKit.
   stripeS710Devkit,
 
+  /// Stripe Reader T600.
+  stripeT600,
+
+  /// Stripe Reader T600 DevKit.
+  stripeT600Devkit,
+
+  /// Stripe Reader T610.
+  stripeT610,
+
+  /// Stripe Reader T610 DevKit.
+  stripeT610Devkit,
+
   /// Verifone V660p
   verifoneV660p,
+
+  /// Verifone V660pa
+  verifoneV660pa,
 
   /// Verifone M425
   verifoneM425,
@@ -190,6 +208,12 @@ enum DeviceType {
 
   /// Verifone UX700 DevKit
   verifoneUx700Devkit,
+
+  /// Verifone VM100
+  verifoneVm100,
+
+  /// Verifone VP100
+  verifoneVp100,
 }
 
 /// A categorization of a reader’s battery charge level.

--- a/stripe_terminal/lib/src/models/tap_to_pay_ux_configuration.dart
+++ b/stripe_terminal/lib/src/models/tap_to_pay_ux_configuration.dart
@@ -31,6 +31,8 @@ enum TapToPayUxConfigurationTapZoneIndicator {
   below,
   front,
   behind,
+  left,
+  right,
 }
 
 class TapToPayUxConfigurationTapZonePosition {

--- a/stripe_terminal/lib/src/models/tip.dart
+++ b/stripe_terminal/lib/src/models/tip.dart
@@ -11,7 +11,8 @@ class Tip with _$Tip {
   /// Portion of the amount that corresponds to a tip
   ///
   /// The value will be null in the following scenarios:
-  /// - tipping is skipped by using the CollectConfiguration.skipTipping flag or by setting TippingConfiguration.eligibleAmount to 0
+  /// - tipping is skipped by using the skipTipping flag in processPaymentIntent or by setting
+  ///   TippingConfiguration.eligibleAmount to 0
   /// - current reader location does not have a tipping config set
   /// If “No tip” is selected on the reader, the value will be 0
   final int? amount;

--- a/stripe_terminal/lib/src/platform/terminal_platform.api.dart
+++ b/stripe_terminal/lib/src/platform/terminal_platform.api.dart
@@ -545,7 +545,6 @@ List<Object?> _$serializeConnectionConfiguration(ConnectionConfiguration deseria
         _$serializeBluetoothConnectionConfiguration(deserialized),
       AppsOnDevicesConnectionConfiguration() =>
         _$serializeAppsOnDevicesConnectionConfiguration(deserialized),
-      HandoffConnectionConfiguration() => _$serializeHandoffConnectionConfiguration(deserialized),
       InternetConnectionConfiguration() => _$serializeInternetConnectionConfiguration(deserialized),
       TapToPayConnectionConfiguration() => _$serializeTapToPayConnectionConfiguration(deserialized),
       UsbConnectionConfiguration() => _$serializeUsbConnectionConfiguration(deserialized),
@@ -560,9 +559,6 @@ List<Object?> _$serializeBluetoothConnectionConfiguration(
 List<Object?> _$serializeAppsOnDevicesConnectionConfiguration(
         AppsOnDevicesConnectionConfiguration deserialized) =>
     ['AppsOnDevicesConnectionConfiguration'];
-List<Object?> _$serializeHandoffConnectionConfiguration(
-        HandoffConnectionConfiguration deserialized) =>
-    ['HandoffConnectionConfiguration'];
 List<Object?> _$serializeInternetConnectionConfiguration(
         InternetConnectionConfiguration deserialized) =>
     ['InternetConnectionConfiguration', deserialized.allowCustomerCancel, deserialized.failIfInUse];
@@ -589,7 +585,6 @@ List<Object?> _$serializeDiscoveryConfiguration(DiscoveryConfiguration deseriali
         _$serializeBluetoothProximityDiscoveryConfiguration(deserialized),
       AppsOnDevicesDiscoveryConfiguration() =>
         _$serializeAppsOnDevicesDiscoveryConfiguration(deserialized),
-      HandoffDiscoveryConfiguration() => _$serializeHandoffDiscoveryConfiguration(deserialized),
       InternetDiscoveryConfiguration() => _$serializeInternetDiscoveryConfiguration(deserialized),
       TapToPayDiscoveryConfiguration() => _$serializeTapToPayDiscoveryConfiguration(deserialized),
       UsbDiscoveryConfiguration() => _$serializeUsbDiscoveryConfiguration(deserialized),
@@ -607,9 +602,6 @@ List<Object?> _$serializeBluetoothProximityDiscoveryConfiguration(
 List<Object?> _$serializeAppsOnDevicesDiscoveryConfiguration(
         AppsOnDevicesDiscoveryConfiguration deserialized) =>
     ['AppsOnDevicesDiscoveryConfiguration'];
-List<Object?> _$serializeHandoffDiscoveryConfiguration(
-        HandoffDiscoveryConfiguration deserialized) =>
-    ['HandoffDiscoveryConfiguration'];
 List<Object?> _$serializeInternetDiscoveryConfiguration(
         InternetDiscoveryConfiguration deserialized) =>
     [
@@ -761,7 +753,6 @@ List<Object?> _$serializeReaderDelegateAbstract(ReaderDelegateAbstract deseriali
     switch (deserialized) {
       MobileReaderDelegate() => _$serializeMobileReaderDelegate(deserialized),
       AppsOnDevicesReaderDelegate() => _$serializeAppsOnDevicesReaderDelegate(deserialized),
-      HandoffReaderDelegate() => _$serializeHandoffReaderDelegate(deserialized),
       InternetReaderDelegate() => _$serializeInternetReaderDelegate(deserialized),
       TapToPayReaderDelegate() => _$serializeTapToPayReaderDelegate(deserialized),
     };
@@ -769,8 +760,6 @@ List<Object?> _$serializeMobileReaderDelegate(MobileReaderDelegate deserialized)
     ['MobileReaderDelegate'];
 List<Object?> _$serializeAppsOnDevicesReaderDelegate(AppsOnDevicesReaderDelegate deserialized) =>
     ['AppsOnDevicesReaderDelegate'];
-List<Object?> _$serializeHandoffReaderDelegate(HandoffReaderDelegate deserialized) =>
-    ['HandoffReaderDelegate'];
 List<Object?> _$serializeInternetReaderDelegate(InternetReaderDelegate deserialized) =>
     ['InternetReaderDelegate'];
 List<Object?> _$serializeTapToPayReaderDelegate(TapToPayReaderDelegate deserialized) =>

--- a/stripe_terminal/lib/src/platform/terminal_platform.api.dart
+++ b/stripe_terminal/lib/src/platform/terminal_platform.api.dart
@@ -35,9 +35,10 @@ class _$TerminalPlatform implements TerminalPlatform {
   }
 
   @override
-  Future<void> clearCachedCredentials() async {
+  Future<ClearCachedCredentialsResult> clearCachedCredentials() async {
     try {
-      await _$channel.invokeMethod('clearCachedCredentials', []);
+      final result = await _$channel.invokeMethod('clearCachedCredentials', []);
+      return _$deserializeClearCachedCredentialsResult(result as List);
     } on PlatformException catch (exception) {
       TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
@@ -482,6 +483,12 @@ Address _$deserializeAddress(List<Object?> serialized) => Address(
     line2: serialized[3] as String?,
     postalCode: serialized[4] as String?,
     state: serialized[5] as String?);
+ClearCachedCredentialsResult _$deserializeClearCachedCredentialsResult(List<Object?> serialized) =>
+    ClearCachedCredentialsResult(
+        isSuccessful: serialized[0] as bool,
+        error: serialized[1] != null
+            ? _$deserializeTerminalException(serialized[1] as List)
+            : null);
 AmountDetails _$deserializeAmountDetails(List<Object?> serialized) =>
     AmountDetails(tip: serialized[0] != null ? _$deserializeTip(serialized[0] as List) : null);
 CardDetails _$deserializeCardDetails(List<Object?> serialized) => CardDetails(

--- a/stripe_terminal/lib/src/platform/terminal_platform.api.dart
+++ b/stripe_terminal/lib/src/platform/terminal_platform.api.dart
@@ -208,7 +208,7 @@ class _$TerminalPlatform implements TerminalPlatform {
   }
 
   @override
-  Future<PaymentIntent> startCollectPaymentMethod({
+  Future<PaymentIntent> startProcessPaymentIntent({
     required int operationId,
     required String paymentIntentId,
     required bool requestDynamicCurrencyConversion,
@@ -218,9 +218,10 @@ class _$TerminalPlatform implements TerminalPlatform {
     required bool shouldUpdatePaymentIntent,
     required bool customerCancellationEnabled,
     required AllowRedisplay allowRedisplay,
+    required ConfirmPaymentIntentConfiguration? confirmConfiguration,
   }) async {
     try {
-      final result = await _$channel.invokeMethod('startCollectPaymentMethod', [
+      final result = await _$channel.invokeMethod('startProcessPaymentIntent', [
         operationId,
         paymentIntentId,
         requestDynamicCurrencyConversion,
@@ -229,7 +230,10 @@ class _$TerminalPlatform implements TerminalPlatform {
         tippingConfiguration != null ? _$serializeTippingConfiguration(tippingConfiguration) : null,
         shouldUpdatePaymentIntent,
         customerCancellationEnabled,
-        allowRedisplay.index
+        allowRedisplay.index,
+        confirmConfiguration != null
+            ? _$serializeConfirmPaymentIntentConfiguration(confirmConfiguration)
+            : null
       ]);
       return _$deserializePaymentIntent(result as List);
     } on PlatformException catch (exception) {
@@ -239,34 +243,9 @@ class _$TerminalPlatform implements TerminalPlatform {
   }
 
   @override
-  Future<void> stopCollectPaymentMethod(int operationId) async {
+  Future<void> stopProcessPaymentIntent(int operationId) async {
     try {
-      await _$channel.invokeMethod('stopCollectPaymentMethod', [operationId]);
-    } on PlatformException catch (exception) {
-      TerminalPlatform._throwIfIsHostException(exception);
-      rethrow;
-    }
-  }
-
-  @override
-  Future<PaymentIntent> startConfirmPaymentIntent(
-    int operationId,
-    String paymentIntentId,
-  ) async {
-    try {
-      final result =
-          await _$channel.invokeMethod('startConfirmPaymentIntent', [operationId, paymentIntentId]);
-      return _$deserializePaymentIntent(result as List);
-    } on PlatformException catch (exception) {
-      TerminalPlatform._throwIfIsHostException(exception);
-      rethrow;
-    }
-  }
-
-  @override
-  Future<void> stopConfirmPaymentIntent(int operationId) async {
-    try {
-      await _$channel.invokeMethod('stopConfirmPaymentIntent', [operationId]);
+      await _$channel.invokeMethod('stopProcessPaymentIntent', [operationId]);
     } on PlatformException catch (exception) {
       TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
@@ -319,14 +298,14 @@ class _$TerminalPlatform implements TerminalPlatform {
   }
 
   @override
-  Future<SetupIntent> startCollectSetupIntentPaymentMethod({
+  Future<SetupIntent> startProcessSetupIntent({
     required int operationId,
     required String setupIntentId,
     required AllowRedisplay allowRedisplay,
     required bool customerCancellationEnabled,
   }) async {
     try {
-      final result = await _$channel.invokeMethod('startCollectSetupIntentPaymentMethod',
+      final result = await _$channel.invokeMethod('startProcessSetupIntent',
           [operationId, setupIntentId, allowRedisplay.index, customerCancellationEnabled]);
       return _$deserializeSetupIntent(result as List);
     } on PlatformException catch (exception) {
@@ -336,34 +315,9 @@ class _$TerminalPlatform implements TerminalPlatform {
   }
 
   @override
-  Future<void> stopCollectSetupIntentPaymentMethod(int operationId) async {
+  Future<void> stopProcessSetupIntent(int operationId) async {
     try {
-      await _$channel.invokeMethod('stopCollectSetupIntentPaymentMethod', [operationId]);
-    } on PlatformException catch (exception) {
-      TerminalPlatform._throwIfIsHostException(exception);
-      rethrow;
-    }
-  }
-
-  @override
-  Future<SetupIntent> startConfirmSetupIntent(
-    int operationId,
-    String setupIntentId,
-  ) async {
-    try {
-      final result =
-          await _$channel.invokeMethod('startConfirmSetupIntent', [operationId, setupIntentId]);
-      return _$deserializeSetupIntent(result as List);
-    } on PlatformException catch (exception) {
-      TerminalPlatform._throwIfIsHostException(exception);
-      rethrow;
-    }
-  }
-
-  @override
-  Future<void> stopConfirmSetupIntent(int operationId) async {
-    try {
-      await _$channel.invokeMethod('stopConfirmSetupIntent', [operationId]);
+      await _$channel.invokeMethod('stopProcessSetupIntent', [operationId]);
     } on PlatformException catch (exception) {
       TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
@@ -382,9 +336,11 @@ class _$TerminalPlatform implements TerminalPlatform {
   }
 
   @override
-  Future<void> startCollectRefundPaymentMethod({
+  Future<Refund> startProcessRefund({
     required int operationId,
-    required String chargeId,
+    required String? chargeId,
+    required String? paymentIntentId,
+    required String? paymentIntentClientSecret,
     required int amount,
     required String currency,
     required Map<String, String>? metadata,
@@ -393,9 +349,11 @@ class _$TerminalPlatform implements TerminalPlatform {
     required bool customerCancellationEnabled,
   }) async {
     try {
-      await _$channel.invokeMethod('startCollectRefundPaymentMethod', [
+      final result = await _$channel.invokeMethod('startProcessRefund', [
         operationId,
         chargeId,
+        paymentIntentId,
+        paymentIntentClientSecret,
         amount,
         currency,
         metadata?.map((k, v) => MapEntry(k, v)),
@@ -403,26 +361,6 @@ class _$TerminalPlatform implements TerminalPlatform {
         refundApplicationFee,
         customerCancellationEnabled
       ]);
-    } on PlatformException catch (exception) {
-      TerminalPlatform._throwIfIsHostException(exception);
-      rethrow;
-    }
-  }
-
-  @override
-  Future<void> stopCollectRefundPaymentMethod(int operationId) async {
-    try {
-      await _$channel.invokeMethod('stopCollectRefundPaymentMethod', [operationId]);
-    } on PlatformException catch (exception) {
-      TerminalPlatform._throwIfIsHostException(exception);
-      rethrow;
-    }
-  }
-
-  @override
-  Future<Refund> startConfirmRefund(int operationId) async {
-    try {
-      final result = await _$channel.invokeMethod('startConfirmRefund', [operationId]);
       return _$deserializeRefund(result as List);
     } on PlatformException catch (exception) {
       TerminalPlatform._throwIfIsHostException(exception);
@@ -431,9 +369,9 @@ class _$TerminalPlatform implements TerminalPlatform {
   }
 
   @override
-  Future<void> stopConfirmRefund(int operationId) async {
+  Future<void> stopProcessRefund(int operationId) async {
     try {
-      await _$channel.invokeMethod('stopConfirmRefund', [operationId]);
+      await _$channel.invokeMethod('stopProcessRefund', [operationId]);
     } on PlatformException catch (exception) {
       TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
@@ -465,6 +403,31 @@ class _$TerminalPlatform implements TerminalPlatform {
     try {
       await _$channel.invokeMethod(
           'setTapToPayUXConfiguration', [_$serializeTapToPayUxConfiguration(configuration)]);
+    } on PlatformException catch (exception) {
+      TerminalPlatform._throwIfIsHostException(exception);
+      rethrow;
+    }
+  }
+
+  @override
+  Future<Reader> startEasyConnect({
+    required int operationId,
+    required EasyConnectConfiguration configuration,
+  }) async {
+    try {
+      final result = await _$channel.invokeMethod(
+          'startEasyConnect', [operationId, _$serializeEasyConnectConfiguration(configuration)]);
+      return _$deserializeReader(result as List);
+    } on PlatformException catch (exception) {
+      TerminalPlatform._throwIfIsHostException(exception);
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> stopEasyConnect(int operationId) async {
+    try {
+      await _$channel.invokeMethod('stopEasyConnect', [operationId]);
     } on PlatformException catch (exception) {
       TerminalPlatform._throwIfIsHostException(exception);
       rethrow;
@@ -571,10 +534,17 @@ Charge _$deserializeCharge(List<Object?> serialized) => Charge(
         serialized[7] != null ? _$deserializePaymentMethodDetails(serialized[7] as List) : null,
     statementDescriptorSuffix: serialized[8] as String?,
     status: ChargeStatus.values[serialized[9] as int]);
+List<Object?> _$serializeConfirmPaymentIntentConfiguration(
+        ConfirmPaymentIntentConfiguration deserialized) =>
+    [
+      deserialized.returnUrl,
+    ];
 List<Object?> _$serializeConnectionConfiguration(ConnectionConfiguration deserialized) =>
     switch (deserialized) {
       BluetoothConnectionConfiguration() =>
         _$serializeBluetoothConnectionConfiguration(deserialized),
+      AppsOnDevicesConnectionConfiguration() =>
+        _$serializeAppsOnDevicesConnectionConfiguration(deserialized),
       HandoffConnectionConfiguration() => _$serializeHandoffConnectionConfiguration(deserialized),
       InternetConnectionConfiguration() => _$serializeInternetConnectionConfiguration(deserialized),
       TapToPayConnectionConfiguration() => _$serializeTapToPayConnectionConfiguration(deserialized),
@@ -587,6 +557,9 @@ List<Object?> _$serializeBluetoothConnectionConfiguration(
       deserialized.autoReconnectOnUnexpectedDisconnect,
       deserialized.locationId
     ];
+List<Object?> _$serializeAppsOnDevicesConnectionConfiguration(
+        AppsOnDevicesConnectionConfiguration deserialized) =>
+    ['AppsOnDevicesConnectionConfiguration'];
 List<Object?> _$serializeHandoffConnectionConfiguration(
         HandoffConnectionConfiguration deserialized) =>
     ['HandoffConnectionConfiguration'];
@@ -614,6 +587,8 @@ List<Object?> _$serializeDiscoveryConfiguration(DiscoveryConfiguration deseriali
       BluetoothDiscoveryConfiguration() => _$serializeBluetoothDiscoveryConfiguration(deserialized),
       BluetoothProximityDiscoveryConfiguration() =>
         _$serializeBluetoothProximityDiscoveryConfiguration(deserialized),
+      AppsOnDevicesDiscoveryConfiguration() =>
+        _$serializeAppsOnDevicesDiscoveryConfiguration(deserialized),
       HandoffDiscoveryConfiguration() => _$serializeHandoffDiscoveryConfiguration(deserialized),
       InternetDiscoveryConfiguration() => _$serializeInternetDiscoveryConfiguration(deserialized),
       TapToPayDiscoveryConfiguration() => _$serializeTapToPayDiscoveryConfiguration(deserialized),
@@ -629,6 +604,9 @@ List<Object?> _$serializeBluetoothDiscoveryConfiguration(
 List<Object?> _$serializeBluetoothProximityDiscoveryConfiguration(
         BluetoothProximityDiscoveryConfiguration deserialized) =>
     ['BluetoothProximityDiscoveryConfiguration', deserialized.isSimulated];
+List<Object?> _$serializeAppsOnDevicesDiscoveryConfiguration(
+        AppsOnDevicesDiscoveryConfiguration deserialized) =>
+    ['AppsOnDevicesDiscoveryConfiguration'];
 List<Object?> _$serializeHandoffDiscoveryConfiguration(
         HandoffDiscoveryConfiguration deserialized) =>
     ['HandoffDiscoveryConfiguration'];
@@ -636,6 +614,9 @@ List<Object?> _$serializeInternetDiscoveryConfiguration(
         InternetDiscoveryConfiguration deserialized) =>
     [
       'InternetDiscoveryConfiguration',
+      deserialized.discoveryFilter != null
+          ? _$serializeDiscoveryFilter(deserialized.discoveryFilter!)
+          : null,
       deserialized.isSimulated,
       deserialized.locationId,
       deserialized.timeout?.inMicroseconds
@@ -645,6 +626,45 @@ List<Object?> _$serializeTapToPayDiscoveryConfiguration(
     ['TapToPayDiscoveryConfiguration', deserialized.isSimulated];
 List<Object?> _$serializeUsbDiscoveryConfiguration(UsbDiscoveryConfiguration deserialized) =>
     ['UsbDiscoveryConfiguration', deserialized.isSimulated, deserialized.timeout?.inMicroseconds];
+List<Object?> _$serializeDiscoveryFilter(DiscoveryFilter deserialized) => switch (deserialized) {
+      DiscoveryFilterByReaderId() => _$serializeDiscoveryFilterByReaderId(deserialized),
+      DiscoveryFilterBySerialNumber() => _$serializeDiscoveryFilterBySerialNumber(deserialized),
+    };
+List<Object?> _$serializeDiscoveryFilterByReaderId(DiscoveryFilterByReaderId deserialized) =>
+    ['DiscoveryFilterByReaderId', deserialized.readerId];
+List<Object?> _$serializeDiscoveryFilterBySerialNumber(
+        DiscoveryFilterBySerialNumber deserialized) =>
+    ['DiscoveryFilterBySerialNumber', deserialized.serialNumber];
+List<Object?> _$serializeEasyConnectConfiguration(EasyConnectConfiguration deserialized) =>
+    switch (deserialized) {
+      InternetEasyConnectConfiguration() =>
+        _$serializeInternetEasyConnectConfiguration(deserialized),
+      AppsOnDevicesEasyConnectionConfiguration() =>
+        _$serializeAppsOnDevicesEasyConnectionConfiguration(deserialized),
+      TapToPayEasyConnectConfiguration() =>
+        _$serializeTapToPayEasyConnectConfiguration(deserialized),
+    };
+List<Object?> _$serializeInternetEasyConnectConfiguration(
+        InternetEasyConnectConfiguration deserialized) =>
+    [
+      'InternetEasyConnectConfiguration',
+      _$serializeInternetConnectionConfiguration(deserialized.connectionConfiguration),
+      _$serializeInternetDiscoveryConfiguration(deserialized.discoveryConfiguration)
+    ];
+List<Object?> _$serializeAppsOnDevicesEasyConnectionConfiguration(
+        AppsOnDevicesEasyConnectionConfiguration deserialized) =>
+    [
+      'AppsOnDevicesEasyConnectionConfiguration',
+      _$serializeAppsOnDevicesConnectionConfiguration(deserialized.connectionConfiguration),
+      _$serializeAppsOnDevicesDiscoveryConfiguration(deserialized.discoveryConfiguration)
+    ];
+List<Object?> _$serializeTapToPayEasyConnectConfiguration(
+        TapToPayEasyConnectConfiguration deserialized) =>
+    [
+      'TapToPayEasyConnectConfiguration',
+      _$serializeTapToPayConnectionConfiguration(deserialized.connectionConfiguration),
+      _$serializeTapToPayDiscoveryConfiguration(deserialized.discoveryConfiguration)
+    ];
 Location _$deserializeLocation(List<Object?> serialized) => Location(
     address: serialized[0] != null ? _$deserializeAddress(serialized[0] as List) : null,
     displayName: serialized[1] as String?,
@@ -740,12 +760,15 @@ Reader _$deserializeReader(List<Object?> serialized) => Reader(
 List<Object?> _$serializeReaderDelegateAbstract(ReaderDelegateAbstract deserialized) =>
     switch (deserialized) {
       MobileReaderDelegate() => _$serializeMobileReaderDelegate(deserialized),
+      AppsOnDevicesReaderDelegate() => _$serializeAppsOnDevicesReaderDelegate(deserialized),
       HandoffReaderDelegate() => _$serializeHandoffReaderDelegate(deserialized),
       InternetReaderDelegate() => _$serializeInternetReaderDelegate(deserialized),
       TapToPayReaderDelegate() => _$serializeTapToPayReaderDelegate(deserialized),
     };
 List<Object?> _$serializeMobileReaderDelegate(MobileReaderDelegate deserialized) =>
     ['MobileReaderDelegate'];
+List<Object?> _$serializeAppsOnDevicesReaderDelegate(AppsOnDevicesReaderDelegate deserialized) =>
+    ['AppsOnDevicesReaderDelegate'];
 List<Object?> _$serializeHandoffReaderDelegate(HandoffReaderDelegate deserialized) =>
     ['HandoffReaderDelegate'];
 List<Object?> _$serializeInternetReaderDelegate(InternetReaderDelegate deserialized) =>

--- a/stripe_terminal/lib/src/platform/terminal_platform.dart
+++ b/stripe_terminal/lib/src/platform/terminal_platform.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:mek_stripe_terminal/mek_stripe_terminal.dart';
 import 'package:mek_stripe_terminal/src/models/card.dart';
 import 'package:mek_stripe_terminal/src/models/cart.dart';
+import 'package:mek_stripe_terminal/src/models/clear_cached_credentials_result.dart';
 import 'package:mek_stripe_terminal/src/models/charge.dart';
 import 'package:mek_stripe_terminal/src/models/connection_configuration.dart';
 import 'package:mek_stripe_terminal/src/models/disconnect_reason.dart';
@@ -41,7 +42,7 @@ abstract class TerminalPlatform {
   Future<void> init({required bool shouldPrintLogs});
 
   @MethodApi(kotlin: MethodApiType.sync, swift: MethodApiType.sync)
-  Future<void> clearCachedCredentials();
+  Future<ClearCachedCredentialsResult> clearCachedCredentials();
 
 //region Reader discovery, connection and updates
 

--- a/stripe_terminal/lib/src/platform/terminal_platform.dart
+++ b/stripe_terminal/lib/src/platform/terminal_platform.dart
@@ -3,12 +3,14 @@ library stripe_terminal;
 import 'dart:async';
 
 import 'package:flutter/services.dart';
+import 'package:mek_stripe_terminal/mek_stripe_terminal.dart';
 import 'package:mek_stripe_terminal/src/models/card.dart';
 import 'package:mek_stripe_terminal/src/models/cart.dart';
 import 'package:mek_stripe_terminal/src/models/charge.dart';
 import 'package:mek_stripe_terminal/src/models/connection_configuration.dart';
 import 'package:mek_stripe_terminal/src/models/disconnect_reason.dart';
 import 'package:mek_stripe_terminal/src/models/discovery_configuration.dart';
+import 'package:mek_stripe_terminal/src/models/easy_connect_configuration.dart';
 import 'package:mek_stripe_terminal/src/models/location.dart';
 import 'package:mek_stripe_terminal/src/models/payment.dart';
 import 'package:mek_stripe_terminal/src/models/payment_intent.dart';
@@ -89,7 +91,7 @@ abstract class TerminalPlatform {
   Future<PaymentIntent> retrievePaymentIntent(String clientSecret);
 
   @MethodApi(swift: MethodApiType.callbacks)
-  Future<PaymentIntent> startCollectPaymentMethod({
+  Future<PaymentIntent> startProcessPaymentIntent({
     required int operationId,
     required String paymentIntentId,
     required bool requestDynamicCurrencyConversion,
@@ -99,14 +101,10 @@ abstract class TerminalPlatform {
     required bool shouldUpdatePaymentIntent,
     required bool customerCancellationEnabled,
     required AllowRedisplay allowRedisplay,
+    required ConfirmPaymentIntentConfiguration? confirmConfiguration,
   });
 
-  Future<void> stopCollectPaymentMethod(int operationId);
-
-  @MethodApi(swift: MethodApiType.callbacks)
-  Future<PaymentIntent> startConfirmPaymentIntent(int operationId, String paymentIntentId);
-
-  Future<void> stopConfirmPaymentIntent(int operationId);
+  Future<void> stopProcessPaymentIntent(int operationId);
 
   Future<PaymentIntent> cancelPaymentIntent(String paymentIntentId);
 //endregion
@@ -124,19 +122,14 @@ abstract class TerminalPlatform {
   Future<SetupIntent> retrieveSetupIntent(String clientSecret);
 
   @MethodApi(swift: MethodApiType.callbacks)
-  Future<SetupIntent> startCollectSetupIntentPaymentMethod({
+  Future<SetupIntent> startProcessSetupIntent({
     required int operationId,
     required String setupIntentId,
     required AllowRedisplay allowRedisplay,
     required bool customerCancellationEnabled,
   });
 
-  Future<void> stopCollectSetupIntentPaymentMethod(int operationId);
-
-  @MethodApi(swift: MethodApiType.callbacks)
-  Future<SetupIntent> startConfirmSetupIntent(int operationId, String setupIntentId);
-
-  Future<void> stopConfirmSetupIntent(int operationId);
+  Future<void> stopProcessSetupIntent(int operationId);
 
   Future<SetupIntent> cancelSetupIntent(String setupIntentId);
 //endregion
@@ -144,9 +137,11 @@ abstract class TerminalPlatform {
 //region Card-present refunds
 
   @MethodApi(swift: MethodApiType.callbacks)
-  Future<void> startCollectRefundPaymentMethod({
+  Future<Refund> startProcessRefund({
     required int operationId,
-    required String chargeId,
+    required String? chargeId,
+    required String? paymentIntentId,
+    required String? paymentIntentClientSecret,
     required int amount,
     required String currency,
     required Map<String, String>? metadata,
@@ -155,12 +150,7 @@ abstract class TerminalPlatform {
     required bool customerCancellationEnabled,
   });
 
-  Future<void> stopCollectRefundPaymentMethod(int operationId);
-
-  @MethodApi(swift: MethodApiType.callbacks)
-  Future<Refund> startConfirmRefund(int operationId);
-
-  Future<void> stopConfirmRefund(int operationId);
+  Future<void> stopProcessRefund(int operationId);
 
 //endregion
 
@@ -172,6 +162,16 @@ abstract class TerminalPlatform {
 
   @MethodApi(kotlin: MethodApiType.sync, swift: MethodApiType.sync)
   Future<void> setTapToPayUXConfiguration(TapToPayUxConfiguration configuration);
+//endregion
+
+//region EasyConnect
+  @MethodApi(swift: MethodApiType.callbacks)
+  Future<Reader> startEasyConnect({
+    required int operationId,
+    required EasyConnectConfiguration configuration,
+  });
+
+  Future<void> stopEasyConnect(int operationId);
 //endregion
 
   // TODO: add support to collectData and setLocalMobileUxConfiguration methods

--- a/stripe_terminal/lib/src/reader_delegates.dart
+++ b/stripe_terminal/lib/src/reader_delegates.dart
@@ -96,9 +96,15 @@ abstract class MobileReaderDelegate extends ReaderDelegateAbstract
   void onReportAvailableUpdate(ReaderSoftwareUpdate update);
 }
 
+/// The [AppsOnDevicesReaderDelegate] class is a listener that should exist for the entire duration of
+/// your connection to a reader. It will receive events related to the status of the reader.
+abstract class AppsOnDevicesReaderDelegate extends ReaderDelegateAbstract
+    with ReaderDelegate, ReaderDisconnectDelegate {}
+
 /// The [HandoffReaderDelegate] class is a listener that should exist for the entire duration of
 /// your connection to a reader. It will receive events related to the status of the reader.
-abstract class HandoffReaderDelegate extends ReaderDelegateAbstract
+@Deprecated('Use AppsOnDevicesReaderDelegate')
+abstract class HandoffReaderDelegate extends AppsOnDevicesReaderDelegate
     with ReaderDelegate, ReaderDisconnectDelegate {}
 
 /// The [InternetReaderDelegate] class is a listener that should exist for the entire duration of

--- a/stripe_terminal/lib/src/terminal.dart
+++ b/stripe_terminal/lib/src/terminal.dart
@@ -17,7 +17,6 @@ import 'package:mek_stripe_terminal/src/models/simultator_configuration.dart';
 import 'package:mek_stripe_terminal/src/models/tap_to_pay_ux_configuration.dart';
 import 'package:mek_stripe_terminal/src/models/tip.dart';
 import 'package:mek_stripe_terminal/src/platform/terminal_platform.dart';
-import 'package:mek_stripe_terminal/src/terminal_exception.dart';
 
 /// Parts documented with "???" are not yet validated
 class Terminal {

--- a/stripe_terminal/lib/src/terminal_exception.dart
+++ b/stripe_terminal/lib/src/terminal_exception.dart
@@ -49,14 +49,13 @@ enum TerminalExceptionCode {
   ///   The user needs to go to Settings > Your App > and enable Bluetooth
   bluetoothPermissionDenied,
 
-  /// [StripeTerminal.confirmPaymentIntent] was called with an unknown or invalid PaymentIntent.
-  /// You must confirm a payment after collecting a payment method. Successfully confirmed payments
-  /// may not be confirmed again.
+  /// [StripeTerminal.processPaymentIntent] was called with an unknown or invalid PaymentIntent.
+  /// You must process a payment after retrieving a PaymentIntent. Successfully processed payments
+  /// may not be processed again.
   confirmInvalidPaymentIntent,
 
-  /// Only Android. [Terminal.confirmPaymentIntent] was called with an unknown or invalid
-  /// [PaymentIntent]. You must confirm a payment after collecting a payment method. Successfully
-  /// confirmed payments may not be confirmed again.
+  /// Only Android. [Terminal.processSetupIntent] was called with an unknown or invalid
+  /// [SetupIntent]. Successfully processed setup intents may not be processed again.
   confirmInvalidSetupIntent,
 
   /// A [PaymentIntent] or [SetupIntent] was referenced using an invalid client secret.
@@ -104,8 +103,8 @@ enum TerminalExceptionCode {
   ///   inputs operation.
   invalidParameter,
 
-  /// Error reported when calling collectPaymentMethod with request dynamic currency conversion and
-  /// a CollectConfiguration with updatePaymentIntent set to false.
+  /// Error reported when calling processPaymentIntent with request dynamic currency conversion and
+  /// updatePaymentIntent set to false.
   /// IOS(SCPErrorRequestDynamicCurrencyConversionRequiresUpdatePaymentIntent)
   requestDynamicCurrencyConversionRequiresUpdatePaymentIntent,
 
@@ -194,7 +193,7 @@ enum TerminalExceptionCode {
   customerConsentRequired,
 
   /// A card can only be used for one transaction, and must be removed after being read. Otherwise,
-  /// subsequent collectPaymentMethod attempts will fail with this error.
+  /// subsequent processPaymentIntent attempts will fail with this error.
   /// Your terminal delegate will receive [ReaderDelegate.onReportReaderEvent] with
   /// [ReaderEventCardRemoved] when the card is removed.
   /// The Chipper 2x and WisePad 3 will beep until the card is removed.
@@ -327,7 +326,7 @@ enum TerminalExceptionCode {
   /// permission to use NFC.
   nfcDisabled,
 
-  /// [StripeTerminal.confirmPaymentIntent] was called from a reader with an unsupported reader version.
+  /// [StripeTerminal.processPaymentIntent] was called from a reader with an unsupported reader version.
   /// You will need to update your reader to the most recent version in order to accept payments.
   /// We suggest you prompt your user to disconnect and reconnect their reader in order to update the reader.
   unsupportedReaderVersion,
@@ -388,7 +387,7 @@ enum TerminalExceptionCode {
   /// to disconnect manually by turning the reader off.
   ///
   /// NOTE: This error will only occur in one of the following calls: [StripeTerminal.createPaymentIntent],
-  /// [StripeTerminal.retrievePaymentIntent], [StripeTerminal.confirmPaymentIntent], and [StripeTerminal.cancelPaymentIntent].
+  /// [StripeTerminal.retrievePaymentIntent], [StripeTerminal.processPaymentIntent], and [StripeTerminal.cancelPaymentIntent].
   sessionExpired,
 
   /// Android:
@@ -444,22 +443,22 @@ enum TerminalExceptionCode {
   /// it correctly (e.g., a closed bank account or a problem with the card)
   refundFailed,
 
-  /// Error reported when collectPaymentMethod or confirmPaymentIntent was called while offline
+  /// Error reported when processPaymentIntent was called while offline
   /// and the card was read using the swipe method.
   /// Payment method data collected using the Swipe card read method cannot be processed online.
-  /// Retry the payment by calling collectPaymentMethod() again.
+  /// Retry the payment by calling processPaymentIntent() again.
   cardSwipeNotAvailable,
 
-  /// Error reported when collectPaymentMethod or confirmPaymentIntent was called while offline
+  /// Error reported when processPaymentIntent was called while offline
   /// and the presented card was an Interac card.
-  /// Retry the payment by calling collectPaymentMethod() again.
+  /// Retry the payment by calling processPaymentIntent() again.
   interacNotSupportedOffline,
 
-  /// Only Android. Error reported when confirmPaymentIntent was called while offline and the
-  /// presented card was authenticated with an online PIN. Retry the payment by calling collectPaymentMethod() again.
+  /// Only Android. Error reported when processPaymentIntent was called while offline and the
+  /// presented card was authenticated with an online PIN. Retry the payment by calling processPaymentIntent() again.
   onlinePinNotSupportedOffline,
 
-  /// Only Android. [Terminal.confirmPaymentIntent] was called with an unknown or invalid
+  /// Only Android. [Terminal.processPaymentIntent] was called with an unknown or invalid
   /// [PaymentIntent]. You must confirm a payment after collecting a payment method. Successfully
   /// confirmed payments may not be confirmed again.
   mobileWalletNotSupportedOnSetupIntents,
@@ -468,11 +467,11 @@ enum TerminalExceptionCode {
   offlineAndCardExpired,
 
   /// Confirming a payment while offline and the card’s verification failed.
-  /// Retry the payment by calling collectPaymentMethod() again and try a different card if the error persists.
+  /// Retry the payment by calling processPaymentIntent() again and try a different card if the error persists.
   offlineTransactionDeclined,
 
-  /// Error reported when collectPaymentMethod was called while online and confirmPaymentIntent was called while offline.
-  /// Retry the payment by calling collectPaymentMethod() again.
+  /// Error reported when processPaymentIntent was called while online and completed while offline.
+  /// Retry the payment by calling processPaymentIntent() again.
   offlineCollectAndConfirmMismatch,
 
   /// Error reported when a test payment attempted to forward while operating in livemode.
@@ -490,12 +489,12 @@ enum TerminalExceptionCode {
   /// 3. Your application attempted to process the PaymentIntent, but it was already forwarded.
   offlinePaymentIntentNotFound,
 
-  /// Only IOS. Error reported when calling collectPaymentMethod with an offline PaymentIntent
-  /// and a CollectConfiguration with updatePaymentIntent set to true.
+  /// Only IOS. Error reported when calling processPaymentIntent with an offline PaymentIntent
+  /// and processPaymentIntent with updatePaymentIntent set to true.
   updatePaymentIntentUnavailableWhileOffline,
 
-  /// Only IOS. Error reported when calling collectPaymentMethod with offline mode enabled and
-  /// a CollectConfiguration with updatePaymentIntent set to true.
+  /// Only IOS. Error reported when calling processPaymentIntent with offline mode enabled and
+  /// processPaymentIntent with updatePaymentIntent set to true.
   updatePaymentIntentUnavailableWhileOfflineModeEnabled,
 
   /// The reader failed to read the data from the presented payment method. If you encounter
@@ -577,7 +576,7 @@ enum TerminalExceptionCode {
   /// Only Ios. Surcharging is not currently available.
   surchargingNotAvailable,
 
-  /// Only Ios. `surchargeNotice` was specified with a CollectConfiguration with updatePaymentIntent set to false.
+  /// Only Ios. `surchargeNotice` was specified with a CollectPaymentIntentConfiguration with updatePaymentIntent set to false.
   surchargeNoticeRequiresUpdatePaymentIntent,
 
   /// Only Ios. Surcharging was attempted while also using dynamic currency conversion.

--- a/stripe_terminal/pubspec.yaml
+++ b/stripe_terminal/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mek_stripe_terminal
 description: A StripeTerminal plugin to discover readers, connect to them and process payments.
-version: 4.6.3
+version: 5.1.1
 repository: https://github.com/BreX900/mek-packages/tree/main/stripe_terminal
 homepage: https://github.com/BreX900/mek-packages/tree/main/stripe_terminal
 topics:

--- a/stripe_terminal/tool/generate_api.dart
+++ b/stripe_terminal/tool/generate_api.dart
@@ -6,6 +6,7 @@ void main() async {
       apiFile: 'lib/src/platform/terminal_platform.dart',
       extraApiFiles: [
         'lib/src/terminal_exception.dart',
+        'lib/src/models/discovery_filter.dart',
       ],
       hostClassSuffix: 'Api',
       packageName: 'mek_stripe_terminal',


### PR DESCRIPTION
# Update stripe_terminal to v5.1.1 
This PR updates the stripe_terminal package to Stripe Terminal SDK v5.1.1.

## Update details

This release includes the changes introduced in Stripe Terminal Android v5.1.1, following the official changelog.

Note: The iOS implementation was not added as I don't have a MacOS device. 


## The following Android updates were tested:
### Easy Connect
The new simplified Easy Connect flow was tested and validated.

### clearCredentials changes
Updated handling of credential cleanup using the new clearCredentials behavior.

### processPaymentIntent
Integration and testing of the updated processPaymentIntent payment flow according to the new SDK API.


Note: consider this as a v1 of the 5.1.1. @BreX900 
