### PR TITLE
fix(stripe_terminal): make ReceiptDetails.authorizationResponseCode nullable

### DIFF
--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/TerminalApi.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/api/TerminalApi.kt
@@ -1324,7 +1324,7 @@ data class ReceiptDetailsApi(
     val applicationCryptogram: String?,
     val applicationPreferredName: String?,
     val authorizationCode: String?,
-    val authorizationResponseCode: String,
+    val authorizationResponseCode: String?,
     val dedicatedFileName: String?,
     val terminalVerificationResults: String?,
     val transactionStatusInformation: String?,

--- a/stripe_terminal/ios/Classes/Api/TerminalApi.swift
+++ b/stripe_terminal/ios/Classes/Api/TerminalApi.swift
@@ -1410,7 +1410,7 @@ struct ReceiptDetailsApi {
     let applicationCryptogram: String?
     let applicationPreferredName: String?
     let authorizationCode: String?
-    let authorizationResponseCode: String
+    let authorizationResponseCode: String?
     let dedicatedFileName: String?
     let terminalVerificationResults: String?
     let transactionStatusInformation: String?

--- a/stripe_terminal/lib/src/models/card.dart
+++ b/stripe_terminal/lib/src/models/card.dart
@@ -92,7 +92,7 @@ class ReceiptDetails with _$ReceiptDetails {
   final String? accountType;
   final String? applicationPreferredName;
   final String? authorizationCode;
-  final String authorizationResponseCode;
+  final String? authorizationResponseCode;
   final String? applicationCryptogram;
   final String? dedicatedFileName;
   final String? transactionStatusInformation;

--- a/stripe_terminal/lib/src/models/card.g.dart
+++ b/stripe_terminal/lib/src/models/card.g.dart
@@ -8,6 +8,7 @@ part of 'card.dart';
 
 mixin _$CardDetails {
   CardDetails get _self => this as CardDetails;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -19,6 +20,7 @@ mixin _$CardDetails {
           _self.expYear == other.expYear &&
           _self.funding == other.funding &&
           _self.last4 == other.last4;
+
   @override
   int get hashCode {
     var hashCode = 0;
@@ -44,6 +46,7 @@ mixin _$CardDetails {
 
 mixin _$CardPresentDetails {
   CardPresentDetails get _self => this as CardPresentDetails;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -62,6 +65,7 @@ mixin _$CardPresentDetails {
               other.incrementalAuthorizationStatus &&
           _self.networks == other.networks &&
           _self.receipt == other.receipt;
+
   @override
   int get hashCode {
     var hashCode = 0;
@@ -101,6 +105,7 @@ mixin _$CardPresentDetails {
 
 mixin _$CardNetworks {
   CardNetworks get _self => this as CardNetworks;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -108,6 +113,7 @@ mixin _$CardNetworks {
           runtimeType == other.runtimeType &&
           $listEquality.equals(_self.available, other.available) &&
           _self.preferred == other.preferred;
+
   @override
   int get hashCode {
     var hashCode = 0;
@@ -125,6 +131,7 @@ mixin _$CardNetworks {
 
 mixin _$ReceiptDetails {
   ReceiptDetails get _self => this as ReceiptDetails;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -140,6 +147,7 @@ mixin _$ReceiptDetails {
               other.transactionStatusInformation &&
           _self.terminalVerificationResults ==
               other.terminalVerificationResults;
+
   @override
   int get hashCode {
     var hashCode = 0;
@@ -172,6 +180,7 @@ mixin _$ReceiptDetails {
 
 mixin _$CardPresentParameters {
   CardPresentParameters get _self => this as CardPresentParameters;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -183,6 +192,7 @@ mixin _$CardPresentParameters {
           _self.requestIncrementalAuthorizationSupport ==
               other.requestIncrementalAuthorizationSupport &&
           _self.requestedPriority == other.requestedPriority;
+
   @override
   int get hashCode {
     var hashCode = 0;

--- a/stripe_terminal/lib/src/models/cart.g.dart
+++ b/stripe_terminal/lib/src/models/cart.g.dart
@@ -8,6 +8,7 @@ part of 'cart.dart';
 
 mixin _$Cart {
   Cart get _self => this as Cart;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -17,6 +18,7 @@ mixin _$Cart {
           _self.tax == other.tax &&
           _self.total == other.total &&
           $listEquality.equals(_self.lineItems, other.lineItems);
+
   @override
   int get hashCode {
     var hashCode = 0;
@@ -38,6 +40,7 @@ mixin _$Cart {
 
 mixin _$CartLineItem {
   CartLineItem get _self => this as CartLineItem;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -46,6 +49,7 @@ mixin _$CartLineItem {
           _self.description == other.description &&
           _self.quantity == other.quantity &&
           _self.amount == other.amount;
+
   @override
   int get hashCode {
     var hashCode = 0;

--- a/stripe_terminal/lib/src/models/charge.g.dart
+++ b/stripe_terminal/lib/src/models/charge.g.dart
@@ -8,6 +8,7 @@ part of 'charge.dart';
 
 mixin _$Charge {
   Charge get _self => this as Charge;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -24,6 +25,7 @@ mixin _$Charge {
           _self.calculatedStatementDescriptor ==
               other.calculatedStatementDescriptor &&
           _self.authorizationCode == other.authorizationCode;
+
   @override
   int get hashCode {
     var hashCode = 0;

--- a/stripe_terminal/lib/src/models/location.g.dart
+++ b/stripe_terminal/lib/src/models/location.g.dart
@@ -8,6 +8,7 @@ part of 'location.dart';
 
 mixin _$Location {
   Location get _self => this as Location;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -18,6 +19,7 @@ mixin _$Location {
           _self.id == other.id &&
           _self.livemode == other.livemode &&
           $mapEquality.equals(_self.metadata, other.metadata);
+
   @override
   int get hashCode {
     var hashCode = 0;
@@ -41,6 +43,7 @@ mixin _$Location {
 
 mixin _$Address {
   Address get _self => this as Address;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -52,6 +55,7 @@ mixin _$Address {
           _self.line2 == other.line2 &&
           _self.postalCode == other.postalCode &&
           _self.state == other.state;
+
   @override
   int get hashCode {
     var hashCode = 0;

--- a/stripe_terminal/lib/src/models/payment_intent.g.dart
+++ b/stripe_terminal/lib/src/models/payment_intent.g.dart
@@ -8,6 +8,7 @@ part of 'payment_intent.dart';
 
 mixin _$PaymentIntent {
   PaymentIntent get _self => this as PaymentIntent;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -43,6 +44,7 @@ mixin _$PaymentIntent {
           _self.receiptEmail == other.receiptEmail &&
           _self.setupFutureUsage == other.setupFutureUsage &&
           _self.transferGroup == other.transferGroup;
+
   @override
   int get hashCode {
     var hashCode = 0;
@@ -116,6 +118,7 @@ mixin _$PaymentIntent {
 
 mixin _$PaymentIntentParameters {
   PaymentIntentParameters get _self => this as PaymentIntentParameters;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -139,6 +142,7 @@ mixin _$PaymentIntentParameters {
           _self.setupFutureUsage == other.setupFutureUsage &&
           _self.paymentMethodOptionsParameters ==
               other.paymentMethodOptionsParameters;
+
   @override
   int get hashCode {
     var hashCode = 0;
@@ -188,12 +192,14 @@ mixin _$PaymentIntentParameters {
 mixin _$PaymentMethodOptionsParameters {
   PaymentMethodOptionsParameters get _self =>
       this as PaymentMethodOptionsParameters;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is PaymentMethodOptionsParameters &&
           runtimeType == other.runtimeType &&
           _self.cardPresentParameters == other.cardPresentParameters;
+
   @override
   int get hashCode {
     var hashCode = 0;

--- a/stripe_terminal/lib/src/models/payment_method.g.dart
+++ b/stripe_terminal/lib/src/models/payment_method.g.dart
@@ -8,6 +8,7 @@ part of 'payment_method.dart';
 
 mixin _$PaymentMethod {
   PaymentMethod get _self => this as PaymentMethod;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -19,6 +20,7 @@ mixin _$PaymentMethod {
           _self.interacPresent == other.interacPresent &&
           _self.customerId == other.customerId &&
           $mapEquality.equals(_self.metadata, other.metadata);
+
   @override
   int get hashCode {
     var hashCode = 0;

--- a/stripe_terminal/lib/src/models/reader.g.dart
+++ b/stripe_terminal/lib/src/models/reader.g.dart
@@ -8,6 +8,7 @@ part of 'reader.dart';
 
 mixin _$Reader {
   Reader get _self => this as Reader;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -25,6 +26,7 @@ mixin _$Reader {
           _self.ipAddress == other.ipAddress &&
           _self.networkStatus == other.networkStatus &&
           _self.label == other.label;
+
   @override
   int get hashCode {
     var hashCode = 0;

--- a/stripe_terminal/lib/src/models/reader_software_update.g.dart
+++ b/stripe_terminal/lib/src/models/reader_software_update.g.dart
@@ -8,6 +8,7 @@ part of 'reader_software_update.dart';
 
 mixin _$ReaderSoftwareUpdate {
   ReaderSoftwareUpdate get _self => this as ReaderSoftwareUpdate;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -21,6 +22,7 @@ mixin _$ReaderSoftwareUpdate {
           _self.settingsVersion == other.settingsVersion &&
           _self.timeEstimate == other.timeEstimate &&
           _self.version == other.version;
+
   @override
   int get hashCode {
     var hashCode = 0;

--- a/stripe_terminal/lib/src/models/refund.g.dart
+++ b/stripe_terminal/lib/src/models/refund.g.dart
@@ -8,6 +8,7 @@ part of 'refund.dart';
 
 mixin _$Refund {
   Refund get _self => this as Refund;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -23,6 +24,7 @@ mixin _$Refund {
           _self.status == other.status &&
           _self.paymentMethodDetails == other.paymentMethodDetails &&
           _self.failureReason == other.failureReason;
+
   @override
   int get hashCode {
     var hashCode = 0;
@@ -56,6 +58,7 @@ mixin _$Refund {
 
 mixin _$PaymentMethodDetails {
   PaymentMethodDetails get _self => this as PaymentMethodDetails;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -63,6 +66,7 @@ mixin _$PaymentMethodDetails {
           runtimeType == other.runtimeType &&
           _self.cardPresent == other.cardPresent &&
           _self.interacPresent == other.interacPresent;
+
   @override
   int get hashCode {
     var hashCode = 0;

--- a/stripe_terminal/lib/src/models/setup_intent.g.dart
+++ b/stripe_terminal/lib/src/models/setup_intent.g.dart
@@ -8,6 +8,7 @@ part of 'setup_intent.dart';
 
 mixin _$SetupIntent {
   SetupIntent get _self => this as SetupIntent;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -20,6 +21,7 @@ mixin _$SetupIntent {
           _self.usage == other.usage &&
           _self.status == other.status &&
           _self.latestAttempt == other.latestAttempt;
+
   @override
   int get hashCode {
     var hashCode = 0;
@@ -47,6 +49,7 @@ mixin _$SetupIntent {
 
 mixin _$SetupAttempt {
   SetupAttempt get _self => this as SetupAttempt;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -61,6 +64,7 @@ mixin _$SetupAttempt {
           _self.paymentMethodDetails == other.paymentMethodDetails &&
           _self.setupIntentId == other.setupIntentId &&
           _self.status == other.status;
+
   @override
   int get hashCode {
     var hashCode = 0;
@@ -93,6 +97,7 @@ mixin _$SetupAttempt {
 mixin _$SetupAttemptPaymentMethodDetails {
   SetupAttemptPaymentMethodDetails get _self =>
       this as SetupAttemptPaymentMethodDetails;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -100,6 +105,7 @@ mixin _$SetupAttemptPaymentMethodDetails {
           runtimeType == other.runtimeType &&
           _self.cardPresent == other.cardPresent &&
           _self.interacPresent == other.interacPresent;
+
   @override
   int get hashCode {
     var hashCode = 0;
@@ -118,6 +124,7 @@ mixin _$SetupAttemptPaymentMethodDetails {
 mixin _$SetupAttemptCardPresentDetails {
   SetupAttemptCardPresentDetails get _self =>
       this as SetupAttemptCardPresentDetails;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -125,6 +132,7 @@ mixin _$SetupAttemptCardPresentDetails {
           runtimeType == other.runtimeType &&
           _self.emvAuthData == other.emvAuthData &&
           _self.generatedCard == other.generatedCard;
+
   @override
   int get hashCode {
     var hashCode = 0;

--- a/stripe_terminal/lib/src/models/tip.g.dart
+++ b/stripe_terminal/lib/src/models/tip.g.dart
@@ -8,12 +8,14 @@ part of 'tip.dart';
 
 mixin _$Tip {
   Tip get _self => this as Tip;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is Tip &&
           runtimeType == other.runtimeType &&
           _self.amount == other.amount;
+
   @override
   int get hashCode {
     var hashCode = 0;
@@ -28,12 +30,14 @@ mixin _$Tip {
 
 mixin _$TippingConfiguration {
   TippingConfiguration get _self => this as TippingConfiguration;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is TippingConfiguration &&
           runtimeType == other.runtimeType &&
           _self.eligibleAmount == other.eligibleAmount;
+
   @override
   int get hashCode {
     var hashCode = 0;

--- a/stripe_terminal/lib/src/platform/terminal_platform.api.dart
+++ b/stripe_terminal/lib/src/platform/terminal_platform.api.dart
@@ -766,7 +766,7 @@ ReceiptDetails _$deserializeReceiptDetails(List<Object?> serialized) => ReceiptD
     applicationCryptogram: serialized[1] as String?,
     applicationPreferredName: serialized[2] as String?,
     authorizationCode: serialized[3] as String?,
-    authorizationResponseCode: serialized[4] as String,
+    authorizationResponseCode: serialized[4] as String?,
     dedicatedFileName: serialized[5] as String?,
     terminalVerificationResults: serialized[6] as String?,
     transactionStatusInformation: serialized[7] as String?);


### PR DESCRIPTION
## Summary

Stripe Android SDK can return `null` for `ReceiptDetails.authorizationResponseCode`, but the Pigeon schema declares it as non-null `String`. This causes a `TypeError: type 'Null' is not a subtype of type 'String' in type cast` inside the auto-generated `_\$deserializeReceiptDetails` (`terminal_platform.api.dart:769`) during `Terminal.confirmPaymentIntent`, which is a hard crash on otherwise-successful transactions.

All other `ReceiptDetails` fields are already `String?`. This change aligns `authorizationResponseCode` with the rest.

## Repro

- Android (observed on Galaxy S22 / Android 16, but reproducible on any device where Stripe omits this field)
- Real Tap to Pay payment via `confirmPaymentIntent`
- App crashes between successful tap and result screen; merchant cannot see final status.

## Stack trace
\`\`\`
TypeError: type 'Null' is not a subtype of type 'String' in type cast
  _\$deserializeReceiptDetails           (terminal_platform.api.dart:769)
  _\$deserializeCardPresentDetails       (terminal_platform.api.dart:547)
  _\$deserializePaymentMethodDetails     (terminal_platform.api.dart:721)
  _\$deserializeCharge                   (terminal_platform.api.dart:571)
  _\$deserializePaymentIntent            (terminal_platform.api.dart:666)
  _\$deserializeTerminalException        (terminal_platform.api.dart:852)
  Terminal.confirmPaymentIntent.<fn>    (terminal.dart:322)
\`\`\`

## Changes
- `lib/src/models/card.dart`: `String authorizationResponseCode` → `String?`
- Regenerated via `dart run tool/generate_api.dart` + `build_runner build` — propagated to:
  - `lib/src/platform/terminal_platform.api.dart` (Dart side)
  - `android/.../TerminalApi.kt` (Kotlin)
  - `ios/Classes/Api/TerminalApi.swift` (Swift)
  - `lib/src/models/card.g.dart` + other `.g.dart`

## Test plan
- [x] Verified that `authorizationResponseCode` is now `as String?` in generated `terminal_platform.api.dart:769`
- [x] No callers of the field rely on non-null contract