### PR TITLE
fix(android): stop force-unwrapping nullable card fields in mappings

### DIFF
--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/TerminalPlugin.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/TerminalPlugin.kt
@@ -67,6 +67,10 @@ class TerminalPlugin : FlutterPlugin, ActivityAware {
     private lateinit var platform: TerminalPlatformPlugin
     private lateinit var discoverReadersController: DiscoverReadersControllerApi
 
+    companion object {
+        private var handlerOwner: TerminalPlugin? = null
+    }
+
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         val discoverReadersSubject = DiscoverReadersSubject()
         discoverReadersController = DiscoverReadersControllerApi(binding.binaryMessenger);
@@ -80,12 +84,16 @@ class TerminalPlugin : FlutterPlugin, ActivityAware {
             discoverReadersSubject = discoverReadersSubject,
         )
         TerminalPlatformApi.setHandler(binding.binaryMessenger, platform)
+        handlerOwner = this
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         if (Terminal.isInitialized()) platform.clean()
         discoverReadersController.removeHandler()
-        TerminalPlatformApi.removeHandler()
+        if (handlerOwner === this) {
+            TerminalPlatformApi.removeHandler()
+            handlerOwner = null
+        }
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {

--- a/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/mappings/CardMappings.kt
+++ b/stripe_terminal/android/src/main/kotlin/mek/stripeterminal/mappings/CardMappings.kt
@@ -40,6 +40,8 @@ fun cardBrandToApi(value: String?): CardBrandApi? {
         "mastercard" -> CardBrandApi.MASTER_CARD
         "unionpay" -> CardBrandApi.UNION_PAY
         "visa" -> CardBrandApi.VISA
+        "interac" -> CardBrandApi.INTERAC
+        "eftpos_au" -> CardBrandApi.EFTPOS_AU
         "unknown" -> null
         else -> null
     }
@@ -77,7 +79,7 @@ fun ReceiptDetails.toApi(): ReceiptDetailsApi {
         accountType = accountType,
         applicationPreferredName = applicationPreferredName,
         authorizationCode = authorizationCode,
-        authorizationResponseCode = authorizationResponseCode!!,
+        authorizationResponseCode = authorizationResponseCode ?: "",
         applicationCryptogram = applicationCryptogram,
         dedicatedFileName = dedicatedFileName,
         transactionStatusInformation = tsi,
@@ -88,7 +90,7 @@ fun ReceiptDetails.toApi(): ReceiptDetailsApi {
 fun CardNetworks.toApi(): CardNetworksApi {
     return CardNetworksApi(
         available =
-        available.map { cardBrandToApi(it)!! },
+        available.mapNotNull { cardBrandToApi(it) },
         preferred = preferred
     )
 }


### PR DESCRIPTION
## The bug

Any call that retrieves a `PaymentIntent` from the API can fail with a misleading error:

```
TerminalException: unexpectedSdkError
  "Unknown error retrieving payment intent from API"
Caused by: java.lang.NullPointerException at mek.stripeterminal.<anon>.onSuccess
```

The Stripe call itself **succeeded**. The NPE is thrown inside the plugin's own `onSuccess`
callback — that is, inside `PaymentIntent.toApi()`. The SDK wraps anything the callback
throws as `unexpectedSdkError`, so the surfaced message blames the network or the API and
completely hides the fact that the crash is a mapping bug in this plugin.

## Root cause

`ReceiptDetails.authorizationResponseCode` is `String?` on the Stripe model, but
`ReceiptDetailsApi.authorizationResponseCode` is non-null, and `CardMappings.kt` bridged
that gap with `!!`:

```kotlin
authorizationResponseCode = authorizationResponseCode!!
```

Stripe leaves `authorization_response_code` null on plenty of real contactless charges.
Whenever the retrieved intent carries such a receipt, the mapping throws.

## Why this looked like a "Discover card" problem

Worth writing down, because the obvious suspect was the wrong one.

Our production incidents were overwhelmingly **Discover** taps — 20 of 21 in the first
window we enumerated. That correlation made the bug look brand-dependent, which pointed
straight at the *other* force-unwrap in the same file:

```kotlin
available = available.map { cardBrandToApi(it)!! }
```

That hypothesis was wrong. Two checks against real charge data ruled it out:

1. `networks.available` on the failing charges was just `["discover"]` — and `"discover"`
   is already mapped by `cardBrandToApi`. The brand path never returned null here.
2. Looking at receipts instead: **24 of 24** failing authorizations had
   `authorization_response_code: null`, and Discover charges that *did* carry an ARC never
   failed.

So the real discriminator is the null authorization response code, not the card brand.
Discover contactless is simply over-represented among receipts that come back without one,
which is why it looked brand-specific for a while.

For us the impact was concrete: this crash sits on the cleanup path that releases an
authorization after a confirm timeout, so the release never landed and customer
authorizations stayed open until Stripe expired them days later.

## The fix

`CardMappings.kt`:

1. `authorizationResponseCode ?: ""` — the actual crash.
2. `available.mapNotNull { cardBrandToApi(it) }` — the same landmine one field over.
   `CardNetworks.available` is a raw `List<String>` straight from the API, and the SDK's
   brand vocabulary includes values `CardBrandApi` has no member for (`girocard`,
   `cartes_bancaires`, and the literal `"unknown"`). Each of those returns null from
   `cardBrandToApi` and would take down the whole `PaymentIntent` mapping. Dropping the
   unmappable entries seemed better than crashing.
3. Added the `"interac"` and `"eftpos_au"` string cases. `CardBrandApi.INTERAC` and
   `EFTPOS_AU` (and their Dart counterparts) already exist — they were just missing from
   the `when`, so those brands silently mapped to null.

Happy to change (1) if you'd rather make `ReceiptDetailsApi.authorizationResponseCode`
nullable instead of defaulting to `""`. I went with the default because it keeps the
generated `TerminalApi.kt` and the wire format untouched; a nullability change would need
a regen on both platforms. Your call — it is a one-line difference.

## Also included: handler teardown across engines

Separate bug, same branch — say the word and I'll split it into its own PR.

`TerminalPlatformApi` keeps its `MethodChannel` and `CoroutineScope` in a companion
object, so they are process-wide. `DiscoverReadersControllerApi` and `TerminalHandlersApi`
next to it use instance fields, so this one is the odd one out.

With more than one `FlutterEngine` in the process, the sequence `attach(A)` → `attach(B)`
→ `detach(A)` makes A's `onDetachedFromEngine` call `TerminalPlatformApi.removeHandler()`,
which nulls the handler **B** just installed. From then on every call on
`mek_stripe_terminal#TerminalPlatform` fails for the rest of the process with:

```
MissingPluginException(No implementation found for method
  startProcessPaymentIntent on channel mek_stripe_terminal#TerminalPlatform)
```

The fix tracks which instance installed the current registration and only tears it down if
that instance still owns it. Skipping the teardown leaks nothing — `setHandler` has
already replaced both statics, so the registration that would have been removed is
unreachable anyway.

## Notes

- **Android only.** iOS has the same shape at `ios/Classes/Mappings/CardMappings.swift:101`
  (`CardBrand(rawValue: ...)!.toApi()!`), left untouched here since I can't test it.
- No changes to generated `TerminalApi.kt`; no enum ordinals moved, so there is no
  Dart/Kotlin serialization desync risk.
