### PR TITLE
[stripe_terminal] [iOS] Adding DispatchQueue.main.async to fetchConnectionToken()

### DIFF
--- a/mek_stripe_terminal/ios/mek_stripe_terminal/Sources/mek_stripe_terminal/Plugin/TerminalDelegatePlugin.swift
+++ b/mek_stripe_terminal/ios/mek_stripe_terminal/Sources/mek_stripe_terminal/Plugin/TerminalDelegatePlugin.swift
@@ -9,14 +9,16 @@ class TerminalDelegatePlugin: NSObject, ConnectionTokenProvider, TerminalDelegat
     }
     
     func fetchConnectionToken(_ completion: @escaping (String?, (any Error)?) -> Void) {
-        self.handlers.requestConnectionToken { result in
-            switch result {
-                case .success(let token):
-                    completion(token, nil)
+        DispatchQueue.main.async {
+            self.handlers.requestConnectionToken { result in
+                switch result {
+                    case .success(let token):
+                        completion(token, nil)
 
-                case .failure(let error):
-                    completion(nil, error)
-                }
+                    case .failure(let error):
+                        completion(nil, error)
+                    }
+            }
         }
     }
 


### PR DESCRIPTION
When running the latest version of mek_stripe_terminal (5.7.2) on iOS I noticed a sporadic warning about requestionConnectionToken firing a channel message on the wrong thread. This PR addresses this by wrapping the call with a DispatchQueue block similar to the other methods in TerminalDelegatePlugin. This also matches the `runOnMainThread` behavior for the corresponding method in the Android code.

Error triggered without this fix:

`[ERROR:flutter/shell/common/shell.cc(1183)] The 'dev.flutter.pigeon.mek_stripe_terminal.TerminalHandlersApi.requestConnectionToken' channel sent a message from native to Flutter on a non-platform thread. Platform channel messages must be sent on the platform thread. Failure to do so may result in data loss or crashes, and must be fixed in the plugin or application code creating that channel.`